### PR TITLE
docs: set Java to 21 and add multi-project validation to DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@ This document describes how to set up your development environment with code qua
 
 ## Prerequisites
 
-- Java 22
+- Java 21 (matching service build configuration)
 - Maven 3.9+
 - Git
 - Docker (for integration tests)
@@ -87,6 +87,27 @@ cd account-service
 
 # Run all quality checks
 ./mvnw clean verify
+```
+
+
+### 3.5 Multi-Project Validation (Monorepo)
+
+This repository includes Java services, a Python MCP server, a React frontend, and a Node.js E2E test suite.
+Run stack-specific checks before opening a PR:
+
+```bash
+# Java services
+(cd account-service && ./mvnw clean verify)
+(cd transaction-service && ./mvnw clean verify)
+
+# Python MCP server
+(cd financial-mcp-server && python -m pytest tests/)
+
+# Frontend
+(cd frontend && npm run lint && npm run test && npm run build)
+
+# E2E tests
+(cd e2e-tests && npm run lint && npm run test)
 ```
 
 ### 4. SonarCloud Setup (Optional for local development)


### PR DESCRIPTION
### Motivation
- Align the documented Java requirement with the service build configuration and provide explicit multi-project validation steps for the monorepo components.

### Description
- Update `DEVELOPMENT.md` to change the Java prerequisite from `Java 22` to `Java 21` and add a new `3.5 Multi-Project Validation (Monorepo)` section with example commands to run checks for `account-service`, `transaction-service`, `financial-mcp-server`, `frontend`, and `e2e-tests`.

### Testing
- No automated tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7872e08f08328bb4b6af742b83abb)