### PR TITLE
[codex] Add admin risk case management

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,47 @@ Default built-in rules:
 
 Open alerts use a `dedupeKey` so repeated evaluations do not create duplicate open alerts for the same rule/user/transaction/window.
 
+### Risk Case Management
+
+The admin Risk Cases page builds an internal case workflow on top of Risk Alerts. Cases are created manually from a selected alert, start unassigned, and can be claimed by an admin for review. Version 1 keeps cases operational only: it does not message customers, lock accounts, reverse transactions, or make automated fraud decisions.
+
+Case APIs use the same `/transaction-api/api/risk/*` frontend proxy and require `ROLE_ADMIN` or `ROLE_INTERNAL_SERVICE`.
+
+```http
+GET   /api/risk/cases?page=&size=&status=&priority=&assignedTo=&userId=&transactionId=&alertId=&from=&to=
+GET   /api/risk/cases/{caseId}
+GET   /api/risk/cases/summary?from=&to=
+POST  /api/risk/cases/from-alert/{alertId}
+PATCH /api/risk/cases/{caseId}/claim
+PATCH /api/risk/cases/{caseId}/status
+POST  /api/risk/cases/{caseId}/notes
+```
+
+Case statuses are `OPEN`, `IN_REVIEW`, `RESOLVED`, and `CLOSED`. Priorities are `LOW`, `MEDIUM`, `HIGH`, and `CRITICAL`; when omitted at creation time, alert severity maps to case priority (`HIGH` -> `HIGH`, `MEDIUM` -> `MEDIUM`, fallback `LOW`). Notes are internal, append-only admin notes.
+
+Example create/status/note bodies:
+
+```json
+{
+  "title": "Review high-value transfer",
+  "priority": "HIGH",
+  "reason": "Manual review requested by admin"
+}
+```
+
+```json
+{
+  "status": "RESOLVED",
+  "resolutionNote": "Reviewed transaction history and no further action required."
+}
+```
+
+```json
+{
+  "note": "Customer transaction pattern looks unusual compared with prior activity."
+}
+```
+
 ## Testing
 
 ### Frontend
@@ -284,6 +325,7 @@ The frontend test suite covers:
 - Admin navigation visibility.
 - Admin audit log summary, filters, event table, detail panel, and API proxy mapping.
 - Admin risk alert summary, filters, queue table, detail panel, status actions, and API proxy mapping.
+- Admin risk case summary, filters, queue table, detail panel, claim/status/note actions, create-from-alert action, and API proxy mapping.
 - Customer and admin Playwright flows.
 
 ### Backend
@@ -299,7 +341,7 @@ cd transaction-service
 .\mvnw.cmd -q -Dtest=TransactionServiceHardeningTest test
 ```
 
-The transaction-service test suite also covers the admin audit controller, audit persistence rules, audit filtering, summary counts, and 90-day cleanup. Risk alert tests cover admin-only access, filters, summary counts, status updates with reviewer metadata, rule generation, dedupe behavior, and non-risky transaction handling.
+The transaction-service test suite also covers the admin audit controller, audit persistence rules, audit filtering, summary counts, and 90-day cleanup. Risk alert tests cover admin-only access, filters, summary counts, status updates with reviewer metadata, rule generation, dedupe behavior, and non-risky transaction handling. Risk case tests cover admin-only access, filters, summary counts, create-from-alert, duplicate open-case handling, claim, status updates, linked alert details, and append-only notes.
 
 ## Demo Evidence
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { AdminAccountsPage } from "./pages/AdminAccountsPage";
 import { AdminAuditLogPage } from "./pages/AdminAuditLogPage";
 import { AdminMonitoringPage } from "./pages/AdminMonitoringPage";
 import { AdminRiskAlertsPage } from "./pages/AdminRiskAlertsPage";
+import { AdminRiskCasesPage } from "./pages/AdminRiskCasesPage";
 import { AdminTransactionsPage } from "./pages/AdminTransactionsPage";
 import { DashboardPage } from "./pages/DashboardPage";
 import { LoginPage } from "./pages/LoginPage";
@@ -30,6 +31,7 @@ export function App() {
             <Route path="admin/transactions" element={<AdminTransactionsPage />} />
             <Route path="admin/audit-log" element={<AdminAuditLogPage />} />
             <Route path="admin/risk-alerts" element={<AdminRiskAlertsPage />} />
+            <Route path="admin/risk-cases" element={<AdminRiskCasesPage />} />
           </Route>
         </Route>
       </Route>

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { Link, NavLink, Outlet } from "react-router-dom";
-import { Activity, ArrowLeftRight, Banknote, ClipboardList, Gauge, Landmark, LogOut, Shield, ShieldAlert, WalletCards } from "lucide-react";
+import { Activity, ArrowLeftRight, Banknote, ClipboardList, FolderKanban, Gauge, Landmark, LogOut, Shield, ShieldAlert, WalletCards } from "lucide-react";
 import clsx from "clsx";
 import { Button } from "./ui";
 import { useAuth } from "../state/AuthProvider";
@@ -16,7 +16,8 @@ const adminItems = [
   { to: "/admin/monitoring", label: "Monitoring", icon: Activity },
   { to: "/admin/transactions", label: "Ops Transactions", icon: Landmark },
   { to: "/admin/audit-log", label: "Audit Log", icon: ClipboardList },
-  { to: "/admin/risk-alerts", label: "Risk Alerts", icon: ShieldAlert }
+  { to: "/admin/risk-alerts", label: "Risk Alerts", icon: ShieldAlert },
+  { to: "/admin/risk-cases", label: "Risk Cases", icon: FolderKanban }
 ];
 
 function NavigationLink({ to, label, icon: Icon }: { to: string; label: string; icon: React.ComponentType<{ className?: string }> }) {

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { apiRequest } from "./api";
-import { searchAuditEvents, searchRiskAlerts, updateRiskAlertStatus } from "./queries";
+import { addRiskCaseNote, claimRiskCase, createRiskCaseFromAlert, searchAuditEvents, searchRiskAlerts, searchRiskCases, updateRiskAlertStatus, updateRiskCaseStatus } from "./queries";
 import { clearSession, saveSession } from "./session";
 
 function tokenFor(payload: object) {
@@ -114,6 +114,62 @@ describe("apiRequest", () => {
       expect.objectContaining({
         method: "PATCH",
         body: JSON.stringify({ status: "ESCALATED", resolutionNote: "Review with fraud ops" })
+      })
+    );
+  });
+
+  it("maps risk case search requests to the transaction proxy", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ content: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      })
+    );
+
+    await searchRiskCases({ userId: "customer", status: "OPEN", assignedTo: "UNASSIGNED" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/transaction-api/api/risk/cases?size=20&sort=createdAt%2Cdesc&userId=customer&status=OPEN&assignedTo=UNASSIGNED",
+      expect.any(Object)
+    );
+  });
+
+  it("creates, claims, updates, and notes risk cases through the transaction proxy", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(() => Promise.resolve(
+      new Response(JSON.stringify({ caseId: "case-1" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      })
+    ));
+
+    await createRiskCaseFromAlert("alert-1", { title: "Review high-value transfer", priority: "HIGH", reason: "Manual review" });
+    await claimRiskCase("case-1");
+    await updateRiskCaseStatus("case-1", { status: "RESOLVED", resolutionNote: "Reviewed" });
+    await addRiskCaseNote("case-1", { note: "Internal note" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/transaction-api/api/risk/cases/from-alert/alert-1",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ title: "Review high-value transfer", priority: "HIGH", reason: "Manual review" })
+      })
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/transaction-api/api/risk/cases/case-1/claim",
+      expect.objectContaining({ method: "PATCH" })
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/transaction-api/api/risk/cases/case-1/status",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ status: "RESOLVED", resolutionNote: "Reviewed" })
+      })
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/transaction-api/api/risk/cases/case-1/notes",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ note: "Internal note" })
       })
     );
   });

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -1,4 +1,4 @@
-import type { Account, AuditLogEntry, AuditSummary, Limits, Page, RiskAlert, RiskSummary, Transaction, TransactionStats } from "../types";
+import type { Account, AuditLogEntry, AuditSummary, Limits, Page, RiskAlert, RiskCase, RiskCaseSummary, RiskSummary, Transaction, TransactionStats } from "../types";
 import { apiRequest, toQuery } from "./api";
 import type { AccountValues, LoginValues, MoneyMovementValues, RegisterValues, ReversalValues, TransferValues } from "./schemas";
 import { getSession } from "./session";
@@ -154,4 +154,32 @@ export function getRiskSummary(params: Record<string, string | undefined> = {}) 
 
 export function updateRiskAlertStatus(alertId: string, values: { status: string; resolutionNote?: string }) {
   return apiRequest<RiskAlert>("transaction", `/api/risk/alerts/${alertId}/status`, { method: "PATCH", body: values });
+}
+
+export function searchRiskCases(params: Record<string, string | number | undefined>) {
+  return apiRequest<Page<RiskCase>>("transaction", `/api/risk/cases${toQuery({ size: 20, sort: "createdAt,desc", ...params })}`);
+}
+
+export function getRiskCase(caseId: string) {
+  return apiRequest<RiskCase>("transaction", `/api/risk/cases/${caseId}`);
+}
+
+export function getRiskCaseSummary(params: Record<string, string | undefined> = {}) {
+  return apiRequest<RiskCaseSummary>("transaction", `/api/risk/cases/summary${toQuery(params)}`);
+}
+
+export function createRiskCaseFromAlert(alertId: string, values: { title?: string; priority?: string; reason?: string }) {
+  return apiRequest<RiskCase>("transaction", `/api/risk/cases/from-alert/${alertId}`, { method: "POST", body: values });
+}
+
+export function claimRiskCase(caseId: string) {
+  return apiRequest<RiskCase>("transaction", `/api/risk/cases/${caseId}/claim`, { method: "PATCH" });
+}
+
+export function updateRiskCaseStatus(caseId: string, values: { status: string; resolutionNote?: string }) {
+  return apiRequest<RiskCase>("transaction", `/api/risk/cases/${caseId}/status`, { method: "PATCH", body: values });
+}
+
+export function addRiskCaseNote(caseId: string, values: { note: string }) {
+  return apiRequest<RiskCase>("transaction", `/api/risk/cases/${caseId}/notes`, { method: "POST", body: values });
 }

--- a/frontend/src/pages/AdminRiskAlertsPage.tsx
+++ b/frontend/src/pages/AdminRiskAlertsPage.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Dispatch, SetStateAction } from "react";
 import { useState } from "react";
 import { Badge, Button, EmptyState, Input, Panel, Select, Stat } from "../components/ui";
-import { getRiskSummary, searchRiskAlerts, updateRiskAlertStatus } from "../lib/queries";
+import { createRiskCaseFromAlert, getRiskSummary, searchRiskAlerts, searchRiskCases, updateRiskAlertStatus } from "../lib/queries";
 import type { RiskAlert, RiskAlertStatus } from "../types";
 
 const defaultFilters = {
@@ -20,9 +20,15 @@ export function AdminRiskAlertsPage() {
   const [filters, setFilters] = useState(defaultFilters);
   const [selected, setSelected] = useState<RiskAlert | null>(null);
   const [resolutionNote, setResolutionNote] = useState("");
+  const [caseMessage, setCaseMessage] = useState("");
 
   const alerts = useQuery({ queryKey: ["risk-alerts", filters], queryFn: () => searchRiskAlerts(filters) });
   const summary = useQuery({ queryKey: ["risk-summary", filters.from, filters.to], queryFn: () => getRiskSummary({ from: filters.from, to: filters.to }) });
+  const selectedCases = useQuery({
+    queryKey: ["risk-cases-for-alert", selected?.alertId],
+    queryFn: () => searchRiskCases({ alertId: selected?.alertId }),
+    enabled: Boolean(selected?.alertId)
+  });
   const statusMutation = useMutation({
     mutationFn: ({ alert, status }: { alert: RiskAlert; status: Exclude<RiskAlertStatus, "OPEN"> }) =>
       updateRiskAlertStatus(alert.alertId, { status, resolutionNote }),
@@ -31,6 +37,18 @@ export function AdminRiskAlertsPage() {
       setResolutionNote(updated.resolutionNote || "");
       queryClient.invalidateQueries({ queryKey: ["risk-alerts"] });
       queryClient.invalidateQueries({ queryKey: ["risk-summary"] });
+    }
+  });
+  const createCaseMutation = useMutation({
+    mutationFn: (alert: RiskAlert) => createRiskCaseFromAlert(alert.alertId, {
+      title: `Review ${alert.alertType}`,
+      priority: alert.severity === "HIGH" ? "HIGH" : "MEDIUM",
+      reason: alert.reason
+    }),
+    onSuccess: (created) => {
+      setCaseMessage(`Case ${created.caseNumber} created`);
+      queryClient.invalidateQueries({ queryKey: ["risk-cases"] });
+      queryClient.invalidateQueries({ queryKey: ["risk-cases-for-alert"] });
     }
   });
 
@@ -85,6 +103,7 @@ export function AdminRiskAlertsPage() {
           {alerts.data?.content.length ? <RiskAlertTable alerts={alerts.data.content} onSelect={(alert) => {
             setSelected(alert);
             setResolutionNote(alert.resolutionNote || "");
+            setCaseMessage("");
           }} /> : null}
         </Panel>
 
@@ -96,9 +115,13 @@ export function AdminRiskAlertsPage() {
             <RiskAlertDetail
               alert={selected}
               resolutionNote={resolutionNote}
+              caseMessage={caseMessage}
+              linkedCaseNumber={selectedCases.data?.content[0]?.caseNumber}
               onResolutionNoteChange={setResolutionNote}
               onStatusChange={(status) => statusMutation.mutate({ alert: selected, status })}
+              onCreateCase={() => createCaseMutation.mutate(selected)}
               isUpdating={statusMutation.isPending}
+              isCreatingCase={createCaseMutation.isPending}
             />
           ) : (
             <EmptyState title="No alert selected" detail="Select a risk alert to inspect and resolve it." />
@@ -149,15 +172,23 @@ function RiskAlertTable({ alerts, onSelect }: { alerts: RiskAlert[]; onSelect: (
 function RiskAlertDetail({
   alert,
   resolutionNote,
+  caseMessage,
+  linkedCaseNumber,
   onResolutionNoteChange,
   onStatusChange,
-  isUpdating
+  onCreateCase,
+  isUpdating,
+  isCreatingCase
 }: {
   alert: RiskAlert;
   resolutionNote: string;
+  caseMessage: string;
+  linkedCaseNumber?: string;
   onResolutionNoteChange: (value: string) => void;
   onStatusChange: (status: Exclude<RiskAlertStatus, "OPEN">) => void;
+  onCreateCase: () => void;
   isUpdating: boolean;
+  isCreatingCase: boolean;
 }) {
   const rows = [
     ["Alert ID", alert.alertId],
@@ -187,6 +218,15 @@ function RiskAlertDetail({
           </div>
         ))}
       </dl>
+      {linkedCaseNumber ? (
+        <div className="rounded-md border border-line bg-white p-3">
+          <p className="text-xs font-medium uppercase text-muted">Linked case</p>
+          <p className="mt-1 text-sm font-medium text-ink">{linkedCaseNumber}</p>
+        </div>
+      ) : (
+        <Button variant="secondary" disabled={isCreatingCase} onClick={onCreateCase}>Create case</Button>
+      )}
+      {caseMessage ? <p className="text-sm font-medium text-brand">{caseMessage}</p> : null}
       <label className="grid gap-1 text-sm">
         <span className="font-medium text-ink">Resolution note</span>
         <textarea

--- a/frontend/src/pages/AdminRiskCasesPage.tsx
+++ b/frontend/src/pages/AdminRiskCasesPage.tsx
@@ -1,0 +1,300 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { Dispatch, SetStateAction } from "react";
+import { useState } from "react";
+import { Badge, Button, EmptyState, Input, Panel, Select, Stat } from "../components/ui";
+import { addRiskCaseNote, claimRiskCase, getRiskCaseSummary, searchRiskCases, updateRiskCaseStatus } from "../lib/queries";
+import type { RiskCase, RiskCasePriority, RiskCaseStatus } from "../types";
+
+const defaultFilters = {
+  status: "",
+  priority: "",
+  assignedTo: "",
+  userId: "",
+  transactionId: "",
+  alertId: "",
+  from: "",
+  to: ""
+};
+
+export function AdminRiskCasesPage() {
+  const queryClient = useQueryClient();
+  const [filters, setFilters] = useState(defaultFilters);
+  const [selected, setSelected] = useState<RiskCase | null>(null);
+  const [resolutionNote, setResolutionNote] = useState("");
+  const [internalNote, setInternalNote] = useState("");
+
+  const cases = useQuery({ queryKey: ["risk-cases", filters], queryFn: () => searchRiskCases(filters) });
+  const summary = useQuery({ queryKey: ["risk-case-summary", filters.from, filters.to], queryFn: () => getRiskCaseSummary({ from: filters.from, to: filters.to }) });
+
+  const claimMutation = useMutation({
+    mutationFn: (riskCase: RiskCase) => claimRiskCase(riskCase.caseId),
+    onSuccess: (updated) => {
+      setSelected(updated);
+      queryClient.invalidateQueries({ queryKey: ["risk-cases"] });
+      queryClient.invalidateQueries({ queryKey: ["risk-case-summary"] });
+    }
+  });
+
+  const statusMutation = useMutation({
+    mutationFn: ({ riskCase, status }: { riskCase: RiskCase; status: RiskCaseStatus }) =>
+      updateRiskCaseStatus(riskCase.caseId, { status, resolutionNote }),
+    onSuccess: (updated) => {
+      setSelected(updated);
+      setResolutionNote(updated.resolutionNote || "");
+      queryClient.invalidateQueries({ queryKey: ["risk-cases"] });
+      queryClient.invalidateQueries({ queryKey: ["risk-case-summary"] });
+    }
+  });
+
+  const noteMutation = useMutation({
+    mutationFn: (riskCase: RiskCase) => addRiskCaseNote(riskCase.caseId, { note: internalNote }),
+    onSuccess: (updated) => {
+      setSelected(updated);
+      setInternalNote("");
+      queryClient.invalidateQueries({ queryKey: ["risk-cases"] });
+    }
+  });
+
+  return (
+    <div className="grid gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Risk Cases</h1>
+        <p className="text-sm text-muted">Internal case workflow for risk alerts that need admin investigation.</p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-5">
+        <Stat label="Total cases" value={formatNumber(summary.data?.totalCases)} />
+        <Stat label="Open" value={<Badge tone={summary.data?.openCases ? "warn" : "good"}>{formatNumber(summary.data?.openCases)}</Badge>} />
+        <Stat label="In review" value={formatNumber(summary.data?.inReviewCases)} />
+        <Stat label="Resolved" value={<Badge tone="good">{formatNumber(summary.data?.resolvedCases)}</Badge>} />
+        <Stat label="Unassigned" value={<Badge tone={summary.data?.unassignedCases ? "warn" : "neutral"}>{formatNumber(summary.data?.unassignedCases)}</Badge>} />
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[1fr_430px]">
+        <Panel
+          title="Case queue"
+          action={
+            <div className="grid w-full max-w-6xl grid-cols-8 gap-2">
+              <Select value={filters.status} onChange={(event) => updateFilter(setFilters, "status", event.target.value)}>
+                <option value="">All status</option>
+                <option value="OPEN">Open</option>
+                <option value="IN_REVIEW">In review</option>
+                <option value="RESOLVED">Resolved</option>
+                <option value="CLOSED">Closed</option>
+              </Select>
+              <Select value={filters.priority} onChange={(event) => updateFilter(setFilters, "priority", event.target.value)}>
+                <option value="">All priority</option>
+                <option value="CRITICAL">Critical</option>
+                <option value="HIGH">High</option>
+                <option value="MEDIUM">Medium</option>
+                <option value="LOW">Low</option>
+              </Select>
+              <Select value={filters.assignedTo} onChange={(event) => updateFilter(setFilters, "assignedTo", event.target.value)}>
+                <option value="">All assignment</option>
+                <option value="UNASSIGNED">Unassigned</option>
+              </Select>
+              <Input placeholder="User ID" value={filters.userId} onChange={(event) => updateFilter(setFilters, "userId", event.target.value)} />
+              <Input placeholder="Transaction ID" value={filters.transactionId} onChange={(event) => updateFilter(setFilters, "transactionId", event.target.value)} />
+              <Input placeholder="Alert ID" value={filters.alertId} onChange={(event) => updateFilter(setFilters, "alertId", event.target.value)} />
+              <Input type="datetime-local" aria-label="From" value={filters.from} onChange={(event) => updateFilter(setFilters, "from", event.target.value)} />
+              <Input type="datetime-local" aria-label="To" value={filters.to} onChange={(event) => updateFilter(setFilters, "to", event.target.value)} />
+            </div>
+          }
+        >
+          {cases.error instanceof Error ? <p className="text-sm text-danger">{cases.error.message}</p> : null}
+          {cases.isLoading ? <p className="text-sm text-muted">Loading risk cases...</p> : null}
+          {!cases.isLoading && !cases.data?.content.length ? <EmptyState title="No risk cases found" detail="Adjust filters to inspect another case queue window." /> : null}
+          {cases.data?.content.length ? <RiskCaseTable cases={cases.data.content} onSelect={(riskCase) => {
+            setSelected(riskCase);
+            setResolutionNote(riskCase.resolutionNote || "");
+            setInternalNote("");
+          }} /> : null}
+        </Panel>
+
+        <Panel title="Case detail" action={selected ? <Button variant="secondary" onClick={() => setSelected(null)}>Clear</Button> : null}>
+          {selected ? (
+            <RiskCaseDetail
+              riskCase={selected}
+              resolutionNote={resolutionNote}
+              internalNote={internalNote}
+              onResolutionNoteChange={setResolutionNote}
+              onInternalNoteChange={setInternalNote}
+              onClaim={() => claimMutation.mutate(selected)}
+              onStatusChange={(status) => statusMutation.mutate({ riskCase: selected, status })}
+              onAddNote={() => noteMutation.mutate(selected)}
+              isUpdating={claimMutation.isPending || statusMutation.isPending || noteMutation.isPending}
+            />
+          ) : (
+            <EmptyState title="No case selected" detail="Select a risk case to inspect alert context, claim it, and add notes." />
+          )}
+        </Panel>
+      </div>
+    </div>
+  );
+}
+
+function RiskCaseTable({ cases, onSelect }: { cases: RiskCase[]; onSelect: (riskCase: RiskCase) => void }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm">
+        <thead className="border-b border-line text-xs uppercase text-muted">
+          <tr>
+            <th className="py-2">Case</th>
+            <th>Priority</th>
+            <th>Status</th>
+            <th>User</th>
+            <th>Transaction</th>
+            <th>Assigned</th>
+            <th>Created</th>
+            <th />
+          </tr>
+        </thead>
+        <tbody>
+          {cases.map((riskCase) => (
+            <tr key={riskCase.caseId} className="border-b border-line last:border-0">
+              <td className="py-3">
+                <p className="font-medium">{riskCase.caseNumber}</p>
+                <p className="text-xs text-muted">{riskCase.title}</p>
+              </td>
+              <td><Badge tone={toneForPriority(riskCase.priority)}>{riskCase.priority}</Badge></td>
+              <td><Badge tone={toneForStatus(riskCase.status)}>{riskCase.status}</Badge></td>
+              <td>{riskCase.userId || "system"}</td>
+              <td className="font-mono text-xs">{riskCase.transactionId || "n/a"}</td>
+              <td>{riskCase.assignedTo || "Unassigned"}</td>
+              <td>{formatDate(riskCase.createdAt)}</td>
+              <td className="text-right">
+                <Button variant="secondary" onClick={() => onSelect(riskCase)}>View {riskCase.caseNumber}</Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RiskCaseDetail({
+  riskCase,
+  resolutionNote,
+  internalNote,
+  onResolutionNoteChange,
+  onInternalNoteChange,
+  onClaim,
+  onStatusChange,
+  onAddNote,
+  isUpdating
+}: {
+  riskCase: RiskCase;
+  resolutionNote: string;
+  internalNote: string;
+  onResolutionNoteChange: (value: string) => void;
+  onInternalNoteChange: (value: string) => void;
+  onClaim: () => void;
+  onStatusChange: (status: RiskCaseStatus) => void;
+  onAddNote: () => void;
+  isUpdating: boolean;
+}) {
+  const rows = [
+    ["Case number", riskCase.caseNumber],
+    ["Title", riskCase.title],
+    ["Status", riskCase.status],
+    ["Priority", riskCase.priority],
+    ["User", riskCase.userId],
+    ["Transaction", riskCase.transactionId],
+    ["Primary alert", riskCase.primaryAlertId],
+    ["Assigned to", riskCase.assignedTo || "Unassigned"],
+    ["Created by", riskCase.createdBy],
+    ["Created", formatDate(riskCase.createdAt)],
+    ["Claimed", riskCase.claimedAt ? formatDate(riskCase.claimedAt) : undefined],
+    ["Closed", riskCase.closedAt ? formatDate(riskCase.closedAt) : undefined]
+  ];
+
+  return (
+    <div className="grid gap-4">
+      <dl className="grid gap-3">
+        {rows.map(([label, value]) => (
+          <div key={label} className="rounded-md border border-line bg-white p-3">
+            <dt className="text-xs font-medium uppercase text-muted">{label}</dt>
+            <dd className="mt-1 break-words text-sm font-medium text-ink">{value || "n/a"}</dd>
+          </div>
+        ))}
+      </dl>
+
+      {riskCase.linkedAlerts?.length ? (
+        <div className="rounded-md border border-line bg-white p-3">
+          <p className="text-xs font-medium uppercase text-muted">Linked alert</p>
+          {riskCase.linkedAlerts.map((alert) => (
+            <div key={alert.alertId} className="mt-2 grid gap-1 text-sm">
+              <p className="font-medium">{alert.alertType}</p>
+              <p className="text-muted">{alert.reason}</p>
+              <p className="font-mono text-xs text-muted">{alert.alertId}</p>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {!riskCase.assignedTo ? <Button variant="secondary" disabled={isUpdating} onClick={onClaim}>Claim case</Button> : null}
+
+      <label className="grid gap-1 text-sm">
+        <span className="font-medium text-ink">Internal note</span>
+        <textarea
+          className="min-h-20 w-full rounded-md border border-line bg-white px-3 py-2 text-sm outline-none focus:border-brand"
+          placeholder="Internal note"
+          value={internalNote}
+          onChange={(event) => onInternalNoteChange(event.target.value)}
+        />
+      </label>
+      <Button variant="secondary" disabled={isUpdating || !internalNote.trim()} onClick={onAddNote}>Add note</Button>
+
+      <div className="grid gap-2">
+        <p className="text-sm font-medium text-ink">Notes</p>
+        {riskCase.notes?.length ? riskCase.notes.map((note) => (
+          <div key={note.noteId} className="rounded-md border border-line bg-white p-3">
+            <p className="text-sm">{note.note}</p>
+            <p className="mt-1 text-xs text-muted">{note.author} - {formatDate(note.createdAt)}</p>
+          </div>
+        )) : <p className="text-sm text-muted">No internal notes yet.</p>}
+      </div>
+
+      <label className="grid gap-1 text-sm">
+        <span className="font-medium text-ink">Resolution note</span>
+        <textarea
+          className="min-h-20 w-full rounded-md border border-line bg-white px-3 py-2 text-sm outline-none focus:border-brand"
+          placeholder="Resolution note"
+          value={resolutionNote}
+          onChange={(event) => onResolutionNoteChange(event.target.value)}
+        />
+      </label>
+      <div className="grid gap-2 sm:grid-cols-3">
+        <Button variant="secondary" disabled={isUpdating} onClick={() => onStatusChange("IN_REVIEW")}>Mark in review</Button>
+        <Button variant="secondary" disabled={isUpdating} onClick={() => onStatusChange("RESOLVED")}>Resolve case</Button>
+        <Button variant="danger" disabled={isUpdating} onClick={() => onStatusChange("CLOSED")}>Close case</Button>
+      </div>
+    </div>
+  );
+}
+
+function updateFilter(setFilters: Dispatch<SetStateAction<typeof defaultFilters>>, key: keyof typeof defaultFilters, value: string) {
+  setFilters((prev) => ({ ...prev, [key]: value }));
+}
+
+function toneForPriority(priority: RiskCasePriority): "neutral" | "good" | "warn" | "bad" | "info" {
+  if (priority === "CRITICAL" || priority === "HIGH") return "bad";
+  if (priority === "MEDIUM") return "warn";
+  return "neutral";
+}
+
+function toneForStatus(status: RiskCaseStatus): "neutral" | "good" | "warn" | "bad" | "info" {
+  if (status === "OPEN") return "warn";
+  if (status === "IN_REVIEW") return "info";
+  if (status === "RESOLVED") return "good";
+  return "neutral";
+}
+
+function formatNumber(value: number | undefined) {
+  return String(value ?? 0);
+}
+
+function formatDate(value: string | undefined) {
+  return value ? new Date(value).toLocaleString() : "n/a";
+}

--- a/frontend/src/test/app.component.test.tsx
+++ b/frontend/src/test/app.component.test.tsx
@@ -92,6 +92,12 @@ function mockFetch(handler?: (url: string, init?: RequestInit) => Promise<Respon
     if (url.includes("/api/risk/summary")) {
       return jsonResponse({ totalAlerts: 0, openAlerts: 0, highSeverityAlerts: 0, escalatedAlerts: 0 });
     }
+    if (url.includes("/api/risk/cases/summary")) {
+      return jsonResponse({ totalCases: 0, openCases: 0, inReviewCases: 0, resolvedCases: 0, closedCases: 0, unassignedCases: 0 });
+    }
+    if (url.includes("/api/risk/cases")) {
+      return jsonResponse(emptyPage);
+    }
     if (url.includes("/api/risk/alerts")) {
       return jsonResponse(emptyPage);
     }
@@ -225,6 +231,7 @@ describe("admin navigation", () => {
     expect(screen.getByRole("link", { name: "Ops Transactions" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Audit Log" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Risk Alerts" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Risk Cases" })).toBeInTheDocument();
   });
 
   it("redirects non-admin users away from admin routes", async () => {
@@ -293,11 +300,28 @@ describe("admin audit log", () => {
 });
 
 describe("admin risk alerts", () => {
-  it("renders summary, filters, table rows, details, and status actions", async () => {
+  it("renders summary, filters, table rows, details, status actions, and create case action", async () => {
     const user = userEvent.setup();
     const { calls } = mockFetch((url, init) => {
       if (url.includes("/api/risk/summary")) {
         return jsonResponse({ totalAlerts: 5, openAlerts: 3, highSeverityAlerts: 2, escalatedAlerts: 1 });
+      }
+      if (url.includes("/api/risk/cases/from-alert/alert-1") && init?.method === "POST") {
+        return jsonResponse({
+          caseId: "case-1",
+          caseNumber: "RC-20260509-0001",
+          status: "OPEN",
+          priority: "HIGH",
+          title: "Review high-value transfer",
+          primaryAlertId: "alert-1",
+          userId: "customer",
+          transactionId: "txn-1",
+          createdBy: "ops",
+          createdAt: "2026-05-09T10:30:00",
+          updatedAt: "2026-05-09T10:30:00",
+          linkedAlerts: [],
+          notes: []
+        });
       }
       if (url.includes("/api/risk/alerts/alert-1/status") && init?.method === "PATCH") {
         return jsonResponse({
@@ -370,6 +394,14 @@ describe("admin risk alerts", () => {
     expect(screen.getByText("Transfer amount exceeded high-value threshold")).toBeInTheDocument();
     expect(screen.getByText("Review sender and recipient")).toBeInTheDocument();
 
+    await user.click(screen.getByRole("button", { name: "Create case" }));
+    expect(await screen.findByText("Case RC-20260509-0001 created")).toBeInTheDocument();
+    expect(calls.some(({ url, init }) =>
+      url.includes("/transaction-api/api/risk/cases/from-alert/alert-1")
+      && init?.method === "POST"
+      && String(init.body).includes("Review HIGH_VALUE_TRANSFER")
+    )).toBe(true);
+
     await user.type(screen.getByPlaceholderText("Resolution note"), "Escalated to fraud operations");
     await user.click(screen.getByRole("button", { name: "Escalate alert" }));
 
@@ -383,6 +415,118 @@ describe("admin risk alerts", () => {
     });
   });
 });
+
+describe("admin risk cases", () => {
+  it("renders summary, filters, table rows, detail panel, claim, status, and notes actions", async () => {
+    const user = userEvent.setup();
+    const { calls } = mockFetch((url, init) => {
+      if (url.includes("/api/risk/cases/summary")) {
+        return jsonResponse({ totalCases: 6, openCases: 3, inReviewCases: 1, resolvedCases: 1, closedCases: 1, unassignedCases: 2 });
+      }
+      if (url.includes("/api/risk/cases/case-1/claim") && init?.method === "PATCH") {
+        return jsonResponse(sampleRiskCase({ assignedTo: "ops", status: "IN_REVIEW", claimedAt: "2026-05-09T10:45:00" }));
+      }
+      if (url.includes("/api/risk/cases/case-1/status") && init?.method === "PATCH") {
+        return jsonResponse(sampleRiskCase({ status: "RESOLVED", resolutionNote: "Reviewed and resolved", closedAt: "2026-05-09T11:00:00" }));
+      }
+      if (url.includes("/api/risk/cases/case-1/notes") && init?.method === "POST") {
+        return jsonResponse(sampleRiskCase({
+          notes: [
+            { noteId: "note-1", author: "ops", note: "Customer pattern needs follow-up", createdAt: "2026-05-09T11:15:00" }
+          ]
+        }));
+      }
+      if (url.includes("/api/risk/cases")) {
+        return jsonResponse({ ...emptyPage, content: [sampleRiskCase()], totalElements: 1, totalPages: 1 });
+      }
+      return undefined;
+    });
+
+    renderApp("/admin/risk-cases", tokenFor({ sub: "ops", roles: ["ROLE_ADMIN"] }));
+
+    expect(await screen.findByRole("heading", { name: "Risk Cases" })).toBeInTheDocument();
+    expect(await screen.findByText("6")).toBeInTheDocument();
+    expect(screen.getByText("RC-20260509-0001")).toBeInTheDocument();
+    expect(screen.getByText("txn-1")).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("User ID"), "customer");
+    await user.type(screen.getByPlaceholderText("Transaction ID"), "txn-1");
+    await user.type(screen.getByPlaceholderText("Alert ID"), "alert-1");
+    await user.selectOptions(screen.getByDisplayValue("All status"), "OPEN");
+    await user.selectOptions(screen.getByDisplayValue("All priority"), "HIGH");
+    await user.selectOptions(screen.getByDisplayValue("All assignment"), "UNASSIGNED");
+
+    await waitFor(() => {
+      expect(calls.some(({ url }) =>
+        url.includes("/transaction-api/api/risk/cases")
+        && url.includes("userId=customer")
+        && url.includes("transactionId=txn-1")
+        && url.includes("alertId=alert-1")
+        && url.includes("status=OPEN")
+        && url.includes("priority=HIGH")
+        && url.includes("assignedTo=UNASSIGNED")
+      )).toBe(true);
+    });
+
+    await user.click(screen.getByRole("button", { name: "View RC-20260509-0001" }));
+    expect(screen.getAllByText("Review high-value transfer").length).toBeGreaterThan(0);
+    expect(screen.getByText("HIGH_VALUE_TRANSFER")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Claim case" }));
+    await waitFor(() => {
+      expect(calls.some(({ url, init }) => url.includes("/transaction-api/api/risk/cases/case-1/claim") && init?.method === "PATCH")).toBe(true);
+    });
+
+    await user.type(screen.getByPlaceholderText("Internal note"), "Customer pattern needs follow-up");
+    await user.click(screen.getByRole("button", { name: "Add note" }));
+    expect(await screen.findByText("Customer pattern needs follow-up")).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("Resolution note"), "Reviewed and resolved");
+    await user.click(screen.getByRole("button", { name: "Resolve case" }));
+
+    await waitFor(() => {
+      expect(calls.some(({ url, init }) =>
+        url.includes("/transaction-api/api/risk/cases/case-1/status")
+        && init?.method === "PATCH"
+        && String(init.body).includes("\"status\":\"RESOLVED\"")
+        && String(init.body).includes("Reviewed and resolved")
+      )).toBe(true);
+    });
+  });
+});
+
+function sampleRiskCase(overrides: Record<string, unknown> = {}) {
+  return {
+    caseId: "case-1",
+    caseNumber: "RC-20260509-0001",
+    status: "OPEN",
+    priority: "HIGH",
+    title: "Review high-value transfer",
+    userId: "customer",
+    transactionId: "txn-1",
+    primaryAlertId: "alert-1",
+    assignedTo: undefined,
+    createdBy: "ops",
+    createdAt: "2026-05-09T10:30:00",
+    updatedAt: "2026-05-09T10:30:00",
+    linkedAlerts: [
+      {
+        alertId: "alert-1",
+        alertType: "HIGH_VALUE_TRANSFER",
+        severity: "HIGH",
+        status: "OPEN",
+        userId: "customer",
+        transactionId: "txn-1",
+        amount: 6000,
+        currency: "USD",
+        reason: "Transfer amount exceeded high-value threshold",
+        createdAt: "2026-05-09T10:15:30"
+      }
+    ],
+    notes: [],
+    ...overrides
+  };
+}
 
 describe("admin monitoring", () => {
   it("renders readable metric summaries and derives alert status", async () => {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -141,3 +141,42 @@ export type RiskSummary = {
   highSeverityAlerts: number;
   escalatedAlerts: number;
 };
+
+export type RiskCaseStatus = "OPEN" | "IN_REVIEW" | "RESOLVED" | "CLOSED";
+export type RiskCasePriority = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+
+export type RiskCaseNote = {
+  noteId: string;
+  author: string;
+  note: string;
+  createdAt: string;
+};
+
+export type RiskCase = {
+  caseId: string;
+  caseNumber: string;
+  status: RiskCaseStatus;
+  priority: RiskCasePriority;
+  title: string;
+  userId?: string;
+  transactionId?: string;
+  primaryAlertId?: string;
+  assignedTo?: string;
+  createdBy: string;
+  createdAt: string;
+  updatedAt?: string;
+  claimedAt?: string;
+  closedAt?: string;
+  resolutionNote?: string;
+  linkedAlerts?: RiskAlert[];
+  notes?: RiskCaseNote[];
+};
+
+export type RiskCaseSummary = {
+  totalCases: number;
+  openCases: number;
+  inReviewCases: number;
+  resolvedCases: number;
+  closedCases: number;
+  unassignedCases: number;
+};

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/controller/RiskCaseController.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/controller/RiskCaseController.java
@@ -1,0 +1,106 @@
+package com.suhasan.finance.transaction_service.controller;
+
+import com.suhasan.finance.transaction_service.dto.RiskCaseCreateRequest;
+import com.suhasan.finance.transaction_service.dto.RiskCaseFilter;
+import com.suhasan.finance.transaction_service.dto.RiskCaseNoteRequest;
+import com.suhasan.finance.transaction_service.dto.RiskCaseResponse;
+import com.suhasan.finance.transaction_service.dto.RiskCaseStatusUpdateRequest;
+import com.suhasan.finance.transaction_service.dto.RiskCaseSummaryResponse;
+import com.suhasan.finance.transaction_service.entity.RiskCasePriority;
+import com.suhasan.finance.transaction_service.entity.RiskCaseStatus;
+import com.suhasan.finance.transaction_service.service.RiskCaseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/risk")
+@RequiredArgsConstructor
+public class RiskCaseController {
+
+    private final RiskCaseService riskCaseService;
+
+    @GetMapping("/cases")
+    public ResponseEntity<Page<RiskCaseResponse>> listCases(
+            @RequestParam(required = false) RiskCaseStatus status,
+            @RequestParam(required = false) RiskCasePriority priority,
+            @RequestParam(required = false) String assignedTo,
+            @RequestParam(required = false) String userId,
+            @RequestParam(required = false) String transactionId,
+            @RequestParam(required = false) String alertId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        RiskCaseFilter filter = RiskCaseFilter.builder()
+                .status(status)
+                .priority(priority)
+                .assignedTo(assignedTo)
+                .userId(userId)
+                .transactionId(transactionId)
+                .alertId(alertId)
+                .from(from)
+                .to(to)
+                .build();
+        return ResponseEntity.ok(riskCaseService.searchCases(filter, pageable));
+    }
+
+    @GetMapping("/cases/summary")
+    public ResponseEntity<RiskCaseSummaryResponse> getSummary(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to) {
+        return ResponseEntity.ok(riskCaseService.getSummary(from, to));
+    }
+
+    @GetMapping("/cases/{caseId}")
+    public ResponseEntity<RiskCaseResponse> getCase(@PathVariable String caseId) {
+        return ResponseEntity.ok(riskCaseService.getCase(caseId));
+    }
+
+    @PostMapping("/cases/from-alert/{alertId}")
+    public ResponseEntity<RiskCaseResponse> createFromAlert(
+            @PathVariable String alertId,
+            @RequestBody(required = false) RiskCaseCreateRequest request,
+            Authentication authentication) {
+        return ResponseEntity.ok(riskCaseService.createFromAlert(alertId, request, currentUser(authentication)));
+    }
+
+    @PatchMapping("/cases/{caseId}/claim")
+    public ResponseEntity<RiskCaseResponse> claimCase(@PathVariable String caseId, Authentication authentication) {
+        return ResponseEntity.ok(riskCaseService.claimCase(caseId, currentUser(authentication)));
+    }
+
+    @PatchMapping("/cases/{caseId}/status")
+    public ResponseEntity<RiskCaseResponse> updateStatus(
+            @PathVariable String caseId,
+            @RequestBody RiskCaseStatusUpdateRequest request,
+            Authentication authentication) {
+        return ResponseEntity.ok(riskCaseService.updateStatus(caseId, request, currentUser(authentication)));
+    }
+
+    @PostMapping("/cases/{caseId}/notes")
+    public ResponseEntity<RiskCaseResponse> addNote(
+            @PathVariable String caseId,
+            @RequestBody RiskCaseNoteRequest request,
+            Authentication authentication) {
+        return ResponseEntity.ok(riskCaseService.addNote(caseId, request, currentUser(authentication)));
+    }
+
+    private String currentUser(Authentication authentication) {
+        return authentication != null ? authentication.getName() : "SYSTEM";
+    }
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/RiskCaseCreateRequest.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/RiskCaseCreateRequest.java
@@ -1,0 +1,19 @@
+package com.suhasan.finance.transaction_service.dto;
+
+import com.suhasan.finance.transaction_service.entity.RiskCasePriority;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RiskCaseCreateRequest {
+    private String title;
+    private RiskCasePriority priority;
+    private String reason;
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/RiskCaseFilter.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/RiskCaseFilter.java
@@ -1,0 +1,21 @@
+package com.suhasan.finance.transaction_service.dto;
+
+import com.suhasan.finance.transaction_service.entity.RiskCasePriority;
+import com.suhasan.finance.transaction_service.entity.RiskCaseStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RiskCaseFilter {
+    private RiskCaseStatus status;
+    private RiskCasePriority priority;
+    private String assignedTo;
+    private String userId;
+    private String transactionId;
+    private String alertId;
+    private LocalDateTime from;
+    private LocalDateTime to;
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/RiskCaseNoteRequest.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/RiskCaseNoteRequest.java
@@ -1,0 +1,14 @@
+package com.suhasan.finance.transaction_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RiskCaseNoteRequest {
+    private String note;
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/RiskCaseResponse.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/RiskCaseResponse.java
@@ -1,0 +1,49 @@
+package com.suhasan.finance.transaction_service.dto;
+
+import com.suhasan.finance.transaction_service.entity.RiskCasePriority;
+import com.suhasan.finance.transaction_service.entity.RiskCaseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RiskCaseResponse {
+    private String caseId;
+    private String caseNumber;
+    private RiskCaseStatus status;
+    private RiskCasePriority priority;
+    private String title;
+    private String userId;
+    private String transactionId;
+    private String primaryAlertId;
+    private String assignedTo;
+    private String createdBy;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime claimedAt;
+    private LocalDateTime closedAt;
+    private String resolutionNote;
+    private List<RiskAlertResponse> linkedAlerts;
+    private List<Note> notes;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Note {
+        private String noteId;
+        private String author;
+        private String note;
+        private LocalDateTime createdAt;
+    }
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/RiskCaseStatusUpdateRequest.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/RiskCaseStatusUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.suhasan.finance.transaction_service.dto;
+
+import com.suhasan.finance.transaction_service.entity.RiskCaseStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RiskCaseStatusUpdateRequest {
+    private RiskCaseStatus status;
+    private String resolutionNote;
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/RiskCaseSummaryResponse.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/RiskCaseSummaryResponse.java
@@ -1,0 +1,11 @@
+package com.suhasan.finance.transaction_service.dto;
+
+public record RiskCaseSummaryResponse(
+        long totalCases,
+        long openCases,
+        long inReviewCases,
+        long resolvedCases,
+        long closedCases,
+        long unassignedCases
+) {
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/entity/RiskCase.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/entity/RiskCase.java
@@ -1,0 +1,130 @@
+package com.suhasan.finance.transaction_service.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "risk_cases", indexes = {
+        @Index(name = "idx_risk_case_number", columnList = "caseNumber"),
+        @Index(name = "idx_risk_case_status", columnList = "status"),
+        @Index(name = "idx_risk_case_priority", columnList = "priority"),
+        @Index(name = "idx_risk_case_user_id", columnList = "userId"),
+        @Index(name = "idx_risk_case_transaction_id", columnList = "transactionId"),
+        @Index(name = "idx_risk_case_primary_alert_id", columnList = "primaryAlertId"),
+        @Index(name = "idx_risk_case_assigned_to", columnList = "assignedTo"),
+        @Index(name = "idx_risk_case_created_at", columnList = "createdAt")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RiskCase {
+
+    @Id
+    @Column(length = 36)
+    private String caseId;
+
+    @Column(nullable = false, unique = true, length = 32)
+    private String caseNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private RiskCaseStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private RiskCasePriority priority;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(length = 128)
+    private String userId;
+
+    @Column(length = 36)
+    private String transactionId;
+
+    @Column(length = 36)
+    private String primaryAlertId;
+
+    @Column(length = 128)
+    private String assignedTo;
+
+    @Column(nullable = false, length = 128)
+    private String createdBy;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime claimedAt;
+
+    private LocalDateTime closedAt;
+
+    @Column(length = 500)
+    private String resolutionNote;
+
+    @Builder.Default
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "risk_case_alerts",
+            joinColumns = @JoinColumn(name = "case_id"),
+            inverseJoinColumns = @JoinColumn(name = "alert_id")
+    )
+    private List<RiskAlert> linkedAlerts = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "riskCase", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RiskCaseNote> notes = new ArrayList<>();
+
+    @PrePersist
+    void onCreate() {
+        if (caseId == null) {
+            caseId = UUID.randomUUID().toString();
+        }
+        if (status == null) {
+            status = RiskCaseStatus.OPEN;
+        }
+        if (priority == null) {
+            priority = RiskCasePriority.LOW;
+        }
+        LocalDateTime now = LocalDateTime.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        if (updatedAt == null) {
+            updatedAt = now;
+        }
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/entity/RiskCaseNote.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/entity/RiskCaseNote.java
@@ -1,0 +1,59 @@
+package com.suhasan.finance.transaction_service.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "risk_case_notes", indexes = {
+        @Index(name = "idx_risk_case_note_case_id", columnList = "caseId"),
+        @Index(name = "idx_risk_case_note_created_at", columnList = "createdAt")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RiskCaseNote {
+
+    @Id
+    @Column(length = 36)
+    private String noteId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "case_id", nullable = false)
+    private RiskCase riskCase;
+
+    @Column(nullable = false, length = 128)
+    private String author;
+
+    @Column(nullable = false, length = 1000)
+    private String note;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    void onCreate() {
+        if (noteId == null) {
+            noteId = UUID.randomUUID().toString();
+        }
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/entity/RiskCasePriority.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/entity/RiskCasePriority.java
@@ -1,0 +1,8 @@
+package com.suhasan.finance.transaction_service.entity;
+
+public enum RiskCasePriority {
+    LOW,
+    MEDIUM,
+    HIGH,
+    CRITICAL
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/entity/RiskCaseStatus.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/entity/RiskCaseStatus.java
@@ -1,0 +1,14 @@
+package com.suhasan.finance.transaction_service.entity;
+
+import java.util.List;
+
+public enum RiskCaseStatus {
+    OPEN,
+    IN_REVIEW,
+    RESOLVED,
+    CLOSED;
+
+    public static List<RiskCaseStatus> activeStatuses() {
+        return List.of(OPEN, IN_REVIEW);
+    }
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/repository/RiskCaseNoteRepository.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/repository/RiskCaseNoteRepository.java
@@ -1,0 +1,9 @@
+package com.suhasan.finance.transaction_service.repository;
+
+import com.suhasan.finance.transaction_service.entity.RiskCaseNote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RiskCaseNoteRepository extends JpaRepository<RiskCaseNote, String> {
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/repository/RiskCaseRepository.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/repository/RiskCaseRepository.java
@@ -1,0 +1,30 @@
+package com.suhasan.finance.transaction_service.repository;
+
+import com.suhasan.finance.transaction_service.entity.RiskCase;
+import com.suhasan.finance.transaction_service.entity.RiskCasePriority;
+import com.suhasan.finance.transaction_service.entity.RiskCaseStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Optional;
+
+@Repository
+public interface RiskCaseRepository extends JpaRepository<RiskCase, String>, JpaSpecificationExecutor<RiskCase> {
+
+    Optional<RiskCase> findFirstByPrimaryAlertIdAndStatusIn(String primaryAlertId, Collection<RiskCaseStatus> statuses);
+
+    default Optional<RiskCase> findOpenCaseByAlertId(String alertId) {
+        return findFirstByPrimaryAlertIdAndStatusIn(alertId, RiskCaseStatus.activeStatuses());
+    }
+
+    long countByCreatedAtBetween(LocalDateTime from, LocalDateTime to);
+
+    long countByStatusAndCreatedAtBetween(RiskCaseStatus status, LocalDateTime from, LocalDateTime to);
+
+    long countByPriorityAndCreatedAtBetween(RiskCasePriority priority, LocalDateTime from, LocalDateTime to);
+
+    long countByAssignedToIsNullAndCreatedAtBetween(LocalDateTime from, LocalDateTime to);
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/service/RiskCaseService.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/service/RiskCaseService.java
@@ -1,0 +1,281 @@
+package com.suhasan.finance.transaction_service.service;
+
+import com.suhasan.finance.transaction_service.dto.RiskAlertResponse;
+import com.suhasan.finance.transaction_service.dto.RiskCaseCreateRequest;
+import com.suhasan.finance.transaction_service.dto.RiskCaseFilter;
+import com.suhasan.finance.transaction_service.dto.RiskCaseNoteRequest;
+import com.suhasan.finance.transaction_service.dto.RiskCaseResponse;
+import com.suhasan.finance.transaction_service.dto.RiskCaseStatusUpdateRequest;
+import com.suhasan.finance.transaction_service.dto.RiskCaseSummaryResponse;
+import com.suhasan.finance.transaction_service.entity.RiskAlert;
+import com.suhasan.finance.transaction_service.entity.RiskAlertSeverity;
+import com.suhasan.finance.transaction_service.entity.RiskCase;
+import com.suhasan.finance.transaction_service.entity.RiskCaseNote;
+import com.suhasan.finance.transaction_service.entity.RiskCasePriority;
+import com.suhasan.finance.transaction_service.entity.RiskCaseStatus;
+import com.suhasan.finance.transaction_service.repository.RiskAlertRepository;
+import com.suhasan.finance.transaction_service.repository.RiskCaseNoteRepository;
+import com.suhasan.finance.transaction_service.repository.RiskCaseRepository;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RiskCaseService {
+
+    private static final DateTimeFormatter CASE_DAY = DateTimeFormatter.BASIC_ISO_DATE;
+
+    private final RiskCaseRepository riskCaseRepository;
+    private final RiskCaseNoteRepository riskCaseNoteRepository;
+    private final RiskAlertRepository riskAlertRepository;
+
+    @Transactional(readOnly = true)
+    public Page<RiskCaseResponse> searchCases(RiskCaseFilter filter, Pageable pageable) {
+        return riskCaseRepository.findAll(toSpecification(filter), pageable)
+                .map(this::toResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public RiskCaseResponse getCase(String caseId) {
+        return riskCaseRepository.findById(caseId)
+                .map(this::toResponse)
+                .orElseThrow(() -> new IllegalArgumentException("Risk case not found: " + caseId));
+    }
+
+    @Transactional(readOnly = true)
+    public RiskCaseSummaryResponse getSummary(LocalDateTime from, LocalDateTime to) {
+        LocalDateTime effectiveFrom = from != null ? from : LocalDateTime.now().minusDays(7);
+        LocalDateTime effectiveTo = to != null ? to : LocalDateTime.now();
+        return new RiskCaseSummaryResponse(
+                riskCaseRepository.countByCreatedAtBetween(effectiveFrom, effectiveTo),
+                riskCaseRepository.countByStatusAndCreatedAtBetween(RiskCaseStatus.OPEN, effectiveFrom, effectiveTo),
+                riskCaseRepository.countByStatusAndCreatedAtBetween(RiskCaseStatus.IN_REVIEW, effectiveFrom, effectiveTo),
+                riskCaseRepository.countByStatusAndCreatedAtBetween(RiskCaseStatus.RESOLVED, effectiveFrom, effectiveTo),
+                riskCaseRepository.countByStatusAndCreatedAtBetween(RiskCaseStatus.CLOSED, effectiveFrom, effectiveTo),
+                riskCaseRepository.countByAssignedToIsNullAndCreatedAtBetween(effectiveFrom, effectiveTo)
+        );
+    }
+
+    @Transactional
+    public RiskCaseResponse createFromAlert(String alertId, RiskCaseCreateRequest request, String createdBy) {
+        return riskCaseRepository.findOpenCaseByAlertId(alertId)
+                .map(this::toResponse)
+                .orElseGet(() -> createNewCase(alertId, request, createdBy));
+    }
+
+    @Transactional
+    public RiskCaseResponse claimCase(String caseId, String admin) {
+        RiskCase riskCase = findCase(caseId);
+        if (hasText(riskCase.getAssignedTo()) && !riskCase.getAssignedTo().equals(admin)) {
+            throw new IllegalArgumentException("Risk case is already assigned to " + riskCase.getAssignedTo());
+        }
+        if (riskCase.getStatus() == RiskCaseStatus.RESOLVED || riskCase.getStatus() == RiskCaseStatus.CLOSED) {
+            throw new IllegalArgumentException("Closed risk cases cannot be claimed");
+        }
+        riskCase.setAssignedTo(admin);
+        riskCase.setClaimedAt(LocalDateTime.now());
+        if (riskCase.getStatus() == RiskCaseStatus.OPEN) {
+            riskCase.setStatus(RiskCaseStatus.IN_REVIEW);
+        }
+        return toResponse(riskCaseRepository.save(riskCase));
+    }
+
+    @Transactional
+    public RiskCaseResponse updateStatus(String caseId, RiskCaseStatusUpdateRequest request, String admin) {
+        if (request.getStatus() == null) {
+            throw new IllegalArgumentException("Case status is required");
+        }
+        RiskCase riskCase = findCase(caseId);
+        riskCase.setStatus(request.getStatus());
+        riskCase.setResolutionNote(request.getResolutionNote());
+        if ((request.getStatus() == RiskCaseStatus.RESOLVED || request.getStatus() == RiskCaseStatus.CLOSED)
+                && riskCase.getClosedAt() == null) {
+            riskCase.setClosedAt(LocalDateTime.now());
+        }
+        if (request.getStatus() == RiskCaseStatus.OPEN || request.getStatus() == RiskCaseStatus.IN_REVIEW) {
+            riskCase.setClosedAt(null);
+        }
+        return toResponse(riskCaseRepository.save(riskCase));
+    }
+
+    @Transactional
+    public RiskCaseResponse addNote(String caseId, RiskCaseNoteRequest request, String author) {
+        if (request == null || !hasText(request.getNote())) {
+            throw new IllegalArgumentException("Note is required");
+        }
+        RiskCase riskCase = findCase(caseId);
+        RiskCaseNote note = RiskCaseNote.builder()
+                .riskCase(riskCase)
+                .author(author)
+                .note(request.getNote().trim())
+                .build();
+        riskCase.getNotes().add(note);
+        riskCaseNoteRepository.save(note);
+        return toResponse(riskCase);
+    }
+
+    private RiskCaseResponse createNewCase(String alertId, RiskCaseCreateRequest request, String createdBy) {
+        RiskAlert alert = riskAlertRepository.findById(alertId)
+                .orElseThrow(() -> new IllegalArgumentException("Risk alert not found: " + alertId));
+        RiskCase riskCase = RiskCase.builder()
+                .caseNumber(nextCaseNumber())
+                .status(RiskCaseStatus.OPEN)
+                .priority(resolvePriority(request, alert))
+                .title(resolveTitle(request, alert))
+                .userId(alert.getUserId())
+                .transactionId(alert.getTransactionId())
+                .primaryAlertId(alert.getAlertId())
+                .createdBy(createdBy)
+                .linkedAlerts(new ArrayList<>(List.of(alert)))
+                .build();
+        if (request != null && hasText(request.getReason())) {
+            RiskCaseNote note = RiskCaseNote.builder()
+                    .riskCase(riskCase)
+                    .author(createdBy)
+                    .note(request.getReason().trim())
+                    .build();
+            riskCase.getNotes().add(note);
+        }
+        return toResponse(riskCaseRepository.save(riskCase));
+    }
+
+    private String nextCaseNumber() {
+        LocalDate today = LocalDate.now();
+        LocalDateTime start = today.atStartOfDay();
+        LocalDateTime end = today.plusDays(1).atStartOfDay().minusNanos(1);
+        long sequence = riskCaseRepository.countByCreatedAtBetween(start, end) + 1;
+        return "RC-" + today.format(CASE_DAY) + "-" + String.format("%04d", sequence);
+    }
+
+    private RiskCasePriority resolvePriority(RiskCaseCreateRequest request, RiskAlert alert) {
+        if (request != null && request.getPriority() != null) {
+            return request.getPriority();
+        }
+        if (alert.getSeverity() == RiskAlertSeverity.HIGH) {
+            return RiskCasePriority.HIGH;
+        }
+        if (alert.getSeverity() == RiskAlertSeverity.MEDIUM) {
+            return RiskCasePriority.MEDIUM;
+        }
+        return RiskCasePriority.LOW;
+    }
+
+    private String resolveTitle(RiskCaseCreateRequest request, RiskAlert alert) {
+        if (request != null && hasText(request.getTitle())) {
+            return request.getTitle().trim();
+        }
+        return "Review " + alert.getAlertType();
+    }
+
+    private RiskCase findCase(String caseId) {
+        return riskCaseRepository.findById(caseId)
+                .orElseThrow(() -> new IllegalArgumentException("Risk case not found: " + caseId));
+    }
+
+    private Specification<RiskCase> toSpecification(RiskCaseFilter filter) {
+        return (root, query, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            if (filter.getStatus() != null) {
+                predicates.add(criteriaBuilder.equal(root.get("status"), filter.getStatus()));
+            }
+            if (filter.getPriority() != null) {
+                predicates.add(criteriaBuilder.equal(root.get("priority"), filter.getPriority()));
+            }
+            if (hasText(filter.getAssignedTo())) {
+                if ("UNASSIGNED".equalsIgnoreCase(filter.getAssignedTo())) {
+                    predicates.add(criteriaBuilder.isNull(root.get("assignedTo")));
+                } else {
+                    predicates.add(criteriaBuilder.equal(root.get("assignedTo"), filter.getAssignedTo()));
+                }
+            }
+            if (hasText(filter.getUserId())) {
+                predicates.add(criteriaBuilder.equal(root.get("userId"), filter.getUserId()));
+            }
+            if (hasText(filter.getTransactionId())) {
+                predicates.add(criteriaBuilder.equal(root.get("transactionId"), filter.getTransactionId()));
+            }
+            if (hasText(filter.getAlertId())) {
+                predicates.add(criteriaBuilder.equal(root.get("primaryAlertId"), filter.getAlertId()));
+                query.distinct(true);
+            }
+            if (filter.getFrom() != null) {
+                predicates.add(criteriaBuilder.greaterThanOrEqualTo(root.get("createdAt"), filter.getFrom()));
+            }
+            if (filter.getTo() != null) {
+                predicates.add(criteriaBuilder.lessThanOrEqualTo(root.get("createdAt"), filter.getTo()));
+            }
+            return criteriaBuilder.and(predicates.toArray(Predicate[]::new));
+        };
+    }
+
+    private RiskCaseResponse toResponse(RiskCase riskCase) {
+        return RiskCaseResponse.builder()
+                .caseId(riskCase.getCaseId())
+                .caseNumber(riskCase.getCaseNumber())
+                .status(riskCase.getStatus())
+                .priority(riskCase.getPriority())
+                .title(riskCase.getTitle())
+                .userId(riskCase.getUserId())
+                .transactionId(riskCase.getTransactionId())
+                .primaryAlertId(riskCase.getPrimaryAlertId())
+                .assignedTo(riskCase.getAssignedTo())
+                .createdBy(riskCase.getCreatedBy())
+                .createdAt(riskCase.getCreatedAt())
+                .updatedAt(riskCase.getUpdatedAt())
+                .claimedAt(riskCase.getClaimedAt())
+                .closedAt(riskCase.getClosedAt())
+                .resolutionNote(riskCase.getResolutionNote())
+                .linkedAlerts(riskCase.getLinkedAlerts().stream().map(this::toAlertResponse).toList())
+                .notes(riskCase.getNotes().stream().map(this::toNoteResponse).toList())
+                .build();
+    }
+
+    private RiskCaseResponse.Note toNoteResponse(RiskCaseNote note) {
+        return RiskCaseResponse.Note.builder()
+                .noteId(note.getNoteId())
+                .author(note.getAuthor())
+                .note(note.getNote())
+                .createdAt(note.getCreatedAt())
+                .build();
+    }
+
+    private RiskAlertResponse toAlertResponse(RiskAlert alert) {
+        return RiskAlertResponse.builder()
+                .alertId(alert.getAlertId())
+                .alertType(alert.getAlertType())
+                .severity(alert.getSeverity())
+                .status(alert.getStatus())
+                .userId(alert.getUserId())
+                .transactionId(alert.getTransactionId())
+                .fromAccountId(alert.getFromAccountId())
+                .toAccountId(alert.getToAccountId())
+                .amount(alert.getAmount())
+                .currency(alert.getCurrency())
+                .reason(alert.getReason())
+                .recommendation(alert.getRecommendation())
+                .dedupeKey(alert.getDedupeKey())
+                .metadata(alert.getMetadata())
+                .createdAt(alert.getCreatedAt())
+                .updatedAt(alert.getUpdatedAt())
+                .reviewedBy(alert.getReviewedBy())
+                .reviewedAt(alert.getReviewedAt())
+                .resolutionNote(alert.getResolutionNote())
+                .build();
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/transaction-service/src/main/resources/db/migration/V10__create_risk_cases.sql
+++ b/transaction-service/src/main/resources/db/migration/V10__create_risk_cases.sql
@@ -1,0 +1,47 @@
+CREATE TABLE risk_cases (
+    case_id VARCHAR(36) PRIMARY KEY,
+    case_number VARCHAR(32) NOT NULL UNIQUE,
+    status VARCHAR(32) NOT NULL,
+    priority VARCHAR(32) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    user_id VARCHAR(128),
+    transaction_id VARCHAR(36),
+    primary_alert_id VARCHAR(36),
+    assigned_to VARCHAR(128),
+    created_by VARCHAR(128) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    claimed_at TIMESTAMP,
+    closed_at TIMESTAMP,
+    resolution_note VARCHAR(500)
+);
+
+CREATE TABLE risk_case_alerts (
+    case_id VARCHAR(36) NOT NULL,
+    alert_id VARCHAR(36) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (case_id, alert_id),
+    CONSTRAINT fk_risk_case_alert_case FOREIGN KEY (case_id) REFERENCES risk_cases (case_id) ON DELETE CASCADE,
+    CONSTRAINT fk_risk_case_alert_alert FOREIGN KEY (alert_id) REFERENCES risk_alerts (alert_id) ON DELETE CASCADE
+);
+
+CREATE TABLE risk_case_notes (
+    note_id VARCHAR(36) PRIMARY KEY,
+    case_id VARCHAR(36) NOT NULL,
+    author VARCHAR(128) NOT NULL,
+    note VARCHAR(1000) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_risk_case_note_case FOREIGN KEY (case_id) REFERENCES risk_cases (case_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_risk_case_number ON risk_cases (case_number);
+CREATE INDEX idx_risk_case_status ON risk_cases (status);
+CREATE INDEX idx_risk_case_priority ON risk_cases (priority);
+CREATE INDEX idx_risk_case_user_id ON risk_cases (user_id);
+CREATE INDEX idx_risk_case_transaction_id ON risk_cases (transaction_id);
+CREATE INDEX idx_risk_case_primary_alert_id ON risk_cases (primary_alert_id);
+CREATE INDEX idx_risk_case_assigned_to ON risk_cases (assigned_to);
+CREATE INDEX idx_risk_case_created_at ON risk_cases (created_at);
+CREATE INDEX idx_risk_case_alert_alert_id ON risk_case_alerts (alert_id);
+CREATE INDEX idx_risk_case_note_case_id ON risk_case_notes (case_id);
+CREATE INDEX idx_risk_case_note_created_at ON risk_case_notes (created_at);

--- a/transaction-service/src/test/java/com/suhasan/finance/transaction_service/controller/RiskCaseControllerTest.java
+++ b/transaction-service/src/test/java/com/suhasan/finance/transaction_service/controller/RiskCaseControllerTest.java
@@ -1,0 +1,237 @@
+package com.suhasan.finance.transaction_service.controller;
+
+import com.suhasan.finance.transaction_service.dto.RiskCaseCreateRequest;
+import com.suhasan.finance.transaction_service.dto.RiskCaseResponse;
+import com.suhasan.finance.transaction_service.dto.RiskCaseStatusUpdateRequest;
+import com.suhasan.finance.transaction_service.dto.RiskCaseSummaryResponse;
+import com.suhasan.finance.transaction_service.dto.RiskCaseNoteRequest;
+import com.suhasan.finance.transaction_service.entity.RiskCasePriority;
+import com.suhasan.finance.transaction_service.entity.RiskCaseStatus;
+import com.suhasan.finance.transaction_service.security.JwtAuthenticationFilter;
+import com.suhasan.finance.transaction_service.service.RiskCaseService;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(RiskCaseController.class)
+@Import(com.suhasan.finance.transaction_service.security.SecurityConfig.class)
+@EnableWebSecurity
+class RiskCaseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RiskCaseService riskCaseService;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUpFilter() throws Exception {
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void listCases_AllowsAdminAndPassesFilters() throws Exception {
+        RiskCaseResponse response = RiskCaseResponse.builder()
+                .caseId("case-1")
+                .caseNumber("RC-20260509-0001")
+                .status(RiskCaseStatus.OPEN)
+                .priority(RiskCasePriority.HIGH)
+                .title("Review high-value transfer")
+                .userId("user-1")
+                .transactionId("txn-1")
+                .primaryAlertId("alert-1")
+                .createdAt(LocalDateTime.parse("2026-05-09T10:15:30"))
+                .updatedAt(LocalDateTime.parse("2026-05-09T10:15:30"))
+                .build();
+        Page<RiskCaseResponse> page = new PageImpl<>(List.of(response), PageRequest.of(0, 20), 1);
+        when(riskCaseService.searchCases(any(), any())).thenReturn(page);
+
+        mockMvc.perform(get("/api/risk/cases")
+                        .param("status", "OPEN")
+                        .param("priority", "HIGH")
+                        .param("assignedTo", "ops")
+                        .param("userId", "user-1")
+                        .param("transactionId", "txn-1")
+                        .param("alertId", "alert-1")
+                        .param("from", "2026-05-01T00:00:00")
+                        .param("to", "2026-05-10T00:00:00"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].caseId").value("case-1"))
+                .andExpect(jsonPath("$.content[0].caseNumber").value("RC-20260509-0001"))
+                .andExpect(jsonPath("$.content[0].status").value("OPEN"))
+                .andExpect(jsonPath("$.content[0].priority").value("HIGH"))
+                .andExpect(jsonPath("$.totalElements").value(1));
+
+        verify(riskCaseService).searchCases(argThat(filter ->
+                        filter.getStatus() == RiskCaseStatus.OPEN
+                                && filter.getPriority() == RiskCasePriority.HIGH
+                                && "ops".equals(filter.getAssignedTo())
+                                && "user-1".equals(filter.getUserId())
+                                && "txn-1".equals(filter.getTransactionId())
+                                && "alert-1".equals(filter.getAlertId())
+                                && LocalDateTime.parse("2026-05-01T00:00:00").equals(filter.getFrom())
+                                && LocalDateTime.parse("2026-05-10T00:00:00").equals(filter.getTo())),
+                any());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void listCases_RejectsNormalUsers() throws Exception {
+        mockMvc.perform(get("/api/risk/cases"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "ops", roles = "ADMIN")
+    void createCaseFromAlert_UsesCurrentAdmin() throws Exception {
+        RiskCaseResponse response = RiskCaseResponse.builder()
+                .caseId("case-1")
+                .caseNumber("RC-20260509-0001")
+                .status(RiskCaseStatus.OPEN)
+                .priority(RiskCasePriority.HIGH)
+                .title("Review high-value transfer")
+                .createdBy("ops")
+                .primaryAlertId("alert-1")
+                .build();
+        when(riskCaseService.createFromAlert(eq("alert-1"), any(RiskCaseCreateRequest.class), eq("ops"))).thenReturn(response);
+
+        mockMvc.perform(post("/api/risk/cases/from-alert/alert-1")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "title": "Review high-value transfer",
+                                  "priority": "HIGH",
+                                  "reason": "Manual review requested by admin"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.caseId").value("case-1"))
+                .andExpect(jsonPath("$.createdBy").value("ops"))
+                .andExpect(jsonPath("$.primaryAlertId").value("alert-1"));
+
+        verify(riskCaseService).createFromAlert(eq("alert-1"), argThat(request ->
+                "Review high-value transfer".equals(request.getTitle())
+                        && request.getPriority() == RiskCasePriority.HIGH
+                        && "Manual review requested by admin".equals(request.getReason())), eq("ops"));
+    }
+
+    @Test
+    @WithMockUser(username = "ops", roles = "ADMIN")
+    void claimCase_AssignsCurrentAdmin() throws Exception {
+        RiskCaseResponse response = RiskCaseResponse.builder()
+                .caseId("case-1")
+                .assignedTo("ops")
+                .status(RiskCaseStatus.IN_REVIEW)
+                .claimedAt(LocalDateTime.parse("2026-05-09T10:30:00"))
+                .build();
+        when(riskCaseService.claimCase("case-1", "ops")).thenReturn(response);
+
+        mockMvc.perform(patch("/api/risk/cases/case-1/claim"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.assignedTo").value("ops"))
+                .andExpect(jsonPath("$.status").value("IN_REVIEW"))
+                .andExpect(jsonPath("$.claimedAt").value("2026-05-09T10:30:00"));
+    }
+
+    @Test
+    @WithMockUser(username = "ops", roles = "ADMIN")
+    void updateCaseStatus_PersistsResolutionNote() throws Exception {
+        RiskCaseResponse response = RiskCaseResponse.builder()
+                .caseId("case-1")
+                .status(RiskCaseStatus.RESOLVED)
+                .resolutionNote("Reviewed and resolved")
+                .closedAt(LocalDateTime.parse("2026-05-09T11:00:00"))
+                .build();
+        when(riskCaseService.updateStatus(eq("case-1"), any(RiskCaseStatusUpdateRequest.class), eq("ops"))).thenReturn(response);
+
+        mockMvc.perform(patch("/api/risk/cases/case-1/status")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "status": "RESOLVED",
+                                  "resolutionNote": "Reviewed and resolved"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("RESOLVED"))
+                .andExpect(jsonPath("$.resolutionNote").value("Reviewed and resolved"))
+                .andExpect(jsonPath("$.closedAt").value("2026-05-09T11:00:00"));
+    }
+
+    @Test
+    @WithMockUser(username = "ops", roles = "ADMIN")
+    void addNote_AppendsInternalNote() throws Exception {
+        RiskCaseResponse response = RiskCaseResponse.builder()
+                .caseId("case-1")
+                .notes(List.of(RiskCaseResponse.Note.builder()
+                        .noteId("note-1")
+                        .author("ops")
+                        .note("Customer pattern needs follow-up")
+                        .createdAt(LocalDateTime.parse("2026-05-09T11:15:00"))
+                        .build()))
+                .build();
+        when(riskCaseService.addNote(eq("case-1"), any(RiskCaseNoteRequest.class), eq("ops"))).thenReturn(response);
+
+        mockMvc.perform(post("/api/risk/cases/case-1/notes")
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "note": "Customer pattern needs follow-up"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.notes[0].noteId").value("note-1"))
+                .andExpect(jsonPath("$.notes[0].author").value("ops"))
+                .andExpect(jsonPath("$.notes[0].note").value("Customer pattern needs follow-up"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void summary_ReturnsCaseCounts() throws Exception {
+        when(riskCaseService.getSummary(any(), any())).thenReturn(new RiskCaseSummaryResponse(8, 4, 2, 1, 1, 3));
+
+        mockMvc.perform(get("/api/risk/cases/summary")
+                        .param("from", "2026-05-01T00:00:00")
+                        .param("to", "2026-05-10T00:00:00"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalCases").value(8))
+                .andExpect(jsonPath("$.openCases").value(4))
+                .andExpect(jsonPath("$.inReviewCases").value(2))
+                .andExpect(jsonPath("$.resolvedCases").value(1))
+                .andExpect(jsonPath("$.closedCases").value(1))
+                .andExpect(jsonPath("$.unassignedCases").value(3));
+    }
+}

--- a/transaction-service/src/test/java/com/suhasan/finance/transaction_service/service/RiskCaseServiceTest.java
+++ b/transaction-service/src/test/java/com/suhasan/finance/transaction_service/service/RiskCaseServiceTest.java
@@ -1,0 +1,169 @@
+package com.suhasan.finance.transaction_service.service;
+
+import com.suhasan.finance.transaction_service.dto.RiskCaseCreateRequest;
+import com.suhasan.finance.transaction_service.dto.RiskCaseNoteRequest;
+import com.suhasan.finance.transaction_service.dto.RiskCaseResponse;
+import com.suhasan.finance.transaction_service.dto.RiskCaseStatusUpdateRequest;
+import com.suhasan.finance.transaction_service.entity.RiskAlert;
+import com.suhasan.finance.transaction_service.entity.RiskAlertSeverity;
+import com.suhasan.finance.transaction_service.entity.RiskAlertStatus;
+import com.suhasan.finance.transaction_service.entity.RiskAlertType;
+import com.suhasan.finance.transaction_service.entity.RiskCase;
+import com.suhasan.finance.transaction_service.entity.RiskCasePriority;
+import com.suhasan.finance.transaction_service.entity.RiskCaseStatus;
+import com.suhasan.finance.transaction_service.repository.RiskAlertRepository;
+import com.suhasan.finance.transaction_service.repository.RiskCaseNoteRepository;
+import com.suhasan.finance.transaction_service.repository.RiskCaseRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RiskCaseServiceTest {
+
+    @Mock
+    private RiskCaseRepository riskCaseRepository;
+
+    @Mock
+    private RiskCaseNoteRepository riskCaseNoteRepository;
+
+    @Mock
+    private RiskAlertRepository riskAlertRepository;
+
+    @InjectMocks
+    private RiskCaseService riskCaseService;
+
+    @Test
+    void createFromAlert_CopiesAlertContextAndDefaultsPriorityFromSeverity() {
+        RiskAlert alert = highValueAlert();
+        when(riskAlertRepository.findById("alert-1")).thenReturn(Optional.of(alert));
+        when(riskCaseRepository.findOpenCaseByAlertId("alert-1")).thenReturn(Optional.empty());
+        when(riskCaseRepository.countByCreatedAtBetween(any(), any())).thenReturn(7L);
+        when(riskCaseRepository.save(any(RiskCase.class))).thenAnswer(invocation -> {
+            RiskCase saved = invocation.getArgument(0);
+            saved.setCaseId("case-1");
+            saved.setCreatedAt(LocalDateTime.parse("2026-05-09T10:30:00"));
+            saved.setUpdatedAt(LocalDateTime.parse("2026-05-09T10:30:00"));
+            return saved;
+        });
+
+        RiskCaseResponse response = riskCaseService.createFromAlert("alert-1",
+                RiskCaseCreateRequest.builder().title("Review high-value transfer").build(),
+                "ops");
+
+        assertThat(response.getCaseId()).isEqualTo("case-1");
+        assertThat(response.getCaseNumber()).isEqualTo("RC-20260509-0008");
+        assertThat(response.getPriority()).isEqualTo(RiskCasePriority.HIGH);
+        assertThat(response.getStatus()).isEqualTo(RiskCaseStatus.OPEN);
+        assertThat(response.getPrimaryAlertId()).isEqualTo("alert-1");
+        assertThat(response.getUserId()).isEqualTo("customer");
+        assertThat(response.getTransactionId()).isEqualTo("txn-1");
+        assertThat(response.getCreatedBy()).isEqualTo("ops");
+
+        ArgumentCaptor<RiskCase> captor = ArgumentCaptor.forClass(RiskCase.class);
+        verify(riskCaseRepository).save(captor.capture());
+        assertThat(captor.getValue().getLinkedAlerts()).containsExactly(alert);
+    }
+
+    @Test
+    void createFromAlert_ReturnsExistingOpenCaseForDuplicateAlert() {
+        RiskCase existing = RiskCase.builder()
+                .caseId("case-1")
+                .caseNumber("RC-20260509-0001")
+                .status(RiskCaseStatus.OPEN)
+                .priority(RiskCasePriority.HIGH)
+                .title("Existing case")
+                .primaryAlertId("alert-1")
+                .createdAt(LocalDateTime.parse("2026-05-09T10:30:00"))
+                .updatedAt(LocalDateTime.parse("2026-05-09T10:30:00"))
+                .build();
+        when(riskCaseRepository.findOpenCaseByAlertId("alert-1")).thenReturn(Optional.of(existing));
+
+        RiskCaseResponse response = riskCaseService.createFromAlert("alert-1", RiskCaseCreateRequest.builder().build(), "ops");
+
+        assertThat(response.getCaseId()).isEqualTo("case-1");
+        assertThat(response.getTitle()).isEqualTo("Existing case");
+    }
+
+    @Test
+    void claimCase_AssignsCurrentAdminAndMovesOpenCaseToInReview() {
+        RiskCase riskCase = RiskCase.builder()
+                .caseId("case-1")
+                .status(RiskCaseStatus.OPEN)
+                .priority(RiskCasePriority.MEDIUM)
+                .title("Review alert")
+                .createdAt(LocalDateTime.parse("2026-05-09T10:30:00"))
+                .updatedAt(LocalDateTime.parse("2026-05-09T10:30:00"))
+                .build();
+        when(riskCaseRepository.findById("case-1")).thenReturn(Optional.of(riskCase));
+        when(riskCaseRepository.save(any(RiskCase.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        RiskCaseResponse response = riskCaseService.claimCase("case-1", "ops");
+
+        assertThat(response.getAssignedTo()).isEqualTo("ops");
+        assertThat(response.getStatus()).isEqualTo(RiskCaseStatus.IN_REVIEW);
+        assertThat(response.getClaimedAt()).isNotNull();
+    }
+
+    @Test
+    void updateStatus_ClosesResolvedCasesWithResolutionNote() {
+        RiskCase riskCase = RiskCase.builder()
+                .caseId("case-1")
+                .status(RiskCaseStatus.IN_REVIEW)
+                .priority(RiskCasePriority.HIGH)
+                .title("Review alert")
+                .createdAt(LocalDateTime.parse("2026-05-09T10:30:00"))
+                .updatedAt(LocalDateTime.parse("2026-05-09T10:30:00"))
+                .build();
+        when(riskCaseRepository.findById("case-1")).thenReturn(Optional.of(riskCase));
+        when(riskCaseRepository.save(any(RiskCase.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        RiskCaseResponse response = riskCaseService.updateStatus("case-1",
+                new RiskCaseStatusUpdateRequest(RiskCaseStatus.RESOLVED, "Reviewed and resolved"),
+                "ops");
+
+        assertThat(response.getStatus()).isEqualTo(RiskCaseStatus.RESOLVED);
+        assertThat(response.getResolutionNote()).isEqualTo("Reviewed and resolved");
+        assertThat(response.getClosedAt()).isNotNull();
+    }
+
+    @Test
+    void addNote_RejectsBlankNotes() {
+        assertThatThrownBy(() -> riskCaseService.addNote("case-1", new RiskCaseNoteRequest(" "), "ops"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Note is required");
+    }
+
+    private RiskAlert highValueAlert() {
+        return RiskAlert.builder()
+                .alertId("alert-1")
+                .alertType(RiskAlertType.HIGH_VALUE_TRANSFER)
+                .severity(RiskAlertSeverity.HIGH)
+                .status(RiskAlertStatus.OPEN)
+                .userId("customer")
+                .transactionId("txn-1")
+                .fromAccountId("101")
+                .toAccountId("202")
+                .amount(new BigDecimal("6000.00"))
+                .currency("USD")
+                .reason("Transfer amount exceeded high-value threshold")
+                .recommendation("Review sender and recipient")
+                .dedupeKey("HIGH_VALUE_TRANSFER:txn-1")
+                .createdAt(LocalDateTime.parse("2026-05-09T10:15:30"))
+                .updatedAt(LocalDateTime.parse("2026-05-09T10:15:30"))
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Add transaction-service risk case storage, APIs, service layer, and tests for manual case workflows from risk alerts.
- Add frontend Risk Cases admin page with summary counters, filters, case table, detail panel, claim/status/note actions, and Risk Alerts create-case integration.
- Update README with API surface, status/priority behavior, admin access rules, limitations, and test coverage.

## Validation
- transaction-service: .\\mvnw.cmd -q test
- account-service: .\\mvnw.cmd -q test
- frontend: npm.cmd test
- frontend: npm.cmd run build
- frontend: npm.cmd run e2e
- git diff --check

## Notes
- V1 case management is operational only. It does not lock accounts, reverse transactions, message customers, or make automated fraud decisions.