### PR TITLE
[codex] Add admin investigation timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,19 @@ Example create/status/note bodies:
 }
 ```
 
+### Investigation Timeline
+
+The admin Investigations page is a read-only workspace for reconstructing what happened across transaction, audit, risk alert, and risk case records. Admins can search by user, transaction, account, alert, or case identifiers and review a single chronological timeline with linked metadata.
+
+Investigation APIs use the `/transaction-api/api/investigations/*` frontend proxy and require `ROLE_ADMIN` or `ROLE_INTERNAL_SERVICE`.
+
+```http
+GET /api/investigations/timeline?userId=&transactionId=&accountId=&alertId=&caseId=&from=&to=&page=&size=
+GET /api/investigations/summary?userId=&transactionId=&accountId=&alertId=&caseId=&from=&to=
+```
+
+Timeline items include `TRANSACTION`, `AUDIT_EVENT`, `RISK_ALERT`, `RISK_CASE`, and `CASE_NOTE` records. Searches by `caseId` expand to the case user, transaction, and linked alert context; searches by `alertId` expand to the alert user and transaction context. Version 1 is read-only and does not update alerts, cases, accounts, or transactions.
+
 ## Testing
 
 ### Frontend
@@ -326,6 +339,7 @@ The frontend test suite covers:
 - Admin audit log summary, filters, event table, detail panel, and API proxy mapping.
 - Admin risk alert summary, filters, queue table, detail panel, status actions, and API proxy mapping.
 - Admin risk case summary, filters, queue table, detail panel, claim/status/note actions, create-from-alert action, and API proxy mapping.
+- Admin investigation summary, search controls, mixed-source timeline, detail panel, and API proxy mapping.
 - Customer and admin Playwright flows.
 
 ### Backend
@@ -341,7 +355,7 @@ cd transaction-service
 .\mvnw.cmd -q -Dtest=TransactionServiceHardeningTest test
 ```
 
-The transaction-service test suite also covers the admin audit controller, audit persistence rules, audit filtering, summary counts, and 90-day cleanup. Risk alert tests cover admin-only access, filters, summary counts, status updates with reviewer metadata, rule generation, dedupe behavior, and non-risky transaction handling. Risk case tests cover admin-only access, filters, summary counts, create-from-alert, duplicate open-case handling, claim, status updates, linked alert details, and append-only notes.
+The transaction-service test suite also covers the admin audit controller, audit persistence rules, audit filtering, summary counts, and 90-day cleanup. Risk alert tests cover admin-only access, filters, summary counts, status updates with reviewer metadata, rule generation, dedupe behavior, and non-risky transaction handling. Risk case tests cover admin-only access, filters, summary counts, create-from-alert, duplicate open-case handling, claim, status updates, linked alert details, and append-only notes. Investigation tests cover admin-only access, search context expansion, mixed-source timeline sorting, summary counts, and empty search results.
 
 ## Demo Evidence
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { RequireAuth } from "./components/RequireAuth";
 import { AccountsPage } from "./pages/AccountsPage";
 import { AdminAccountsPage } from "./pages/AdminAccountsPage";
 import { AdminAuditLogPage } from "./pages/AdminAuditLogPage";
+import { AdminInvestigationsPage } from "./pages/AdminInvestigationsPage";
 import { AdminMonitoringPage } from "./pages/AdminMonitoringPage";
 import { AdminRiskAlertsPage } from "./pages/AdminRiskAlertsPage";
 import { AdminRiskCasesPage } from "./pages/AdminRiskCasesPage";
@@ -32,6 +33,7 @@ export function App() {
             <Route path="admin/audit-log" element={<AdminAuditLogPage />} />
             <Route path="admin/risk-alerts" element={<AdminRiskAlertsPage />} />
             <Route path="admin/risk-cases" element={<AdminRiskCasesPage />} />
+            <Route path="admin/investigations" element={<AdminInvestigationsPage />} />
           </Route>
         </Route>
       </Route>

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { Link, NavLink, Outlet } from "react-router-dom";
-import { Activity, ArrowLeftRight, Banknote, ClipboardList, FolderKanban, Gauge, Landmark, LogOut, Shield, ShieldAlert, WalletCards } from "lucide-react";
+import { Activity, ArrowLeftRight, Banknote, ClipboardList, FolderKanban, Gauge, Landmark, LogOut, Search, Shield, ShieldAlert, WalletCards } from "lucide-react";
 import clsx from "clsx";
 import { Button } from "./ui";
 import { useAuth } from "../state/AuthProvider";
@@ -17,7 +17,8 @@ const adminItems = [
   { to: "/admin/transactions", label: "Ops Transactions", icon: Landmark },
   { to: "/admin/audit-log", label: "Audit Log", icon: ClipboardList },
   { to: "/admin/risk-alerts", label: "Risk Alerts", icon: ShieldAlert },
-  { to: "/admin/risk-cases", label: "Risk Cases", icon: FolderKanban }
+  { to: "/admin/risk-cases", label: "Risk Cases", icon: FolderKanban },
+  { to: "/admin/investigations", label: "Investigations", icon: Search }
 ];
 
 function NavigationLink({ to, label, icon: Icon }: { to: string; label: string; icon: React.ComponentType<{ className?: string }> }) {

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { apiRequest } from "./api";
-import { addRiskCaseNote, claimRiskCase, createRiskCaseFromAlert, searchAuditEvents, searchRiskAlerts, searchRiskCases, updateRiskAlertStatus, updateRiskCaseStatus } from "./queries";
+import { addRiskCaseNote, claimRiskCase, createRiskCaseFromAlert, getInvestigationSummary, getInvestigationTimeline, searchAuditEvents, searchRiskAlerts, searchRiskCases, updateRiskAlertStatus, updateRiskCaseStatus } from "./queries";
 import { clearSession, saveSession } from "./session";
 
 function tokenFor(payload: object) {
@@ -171,6 +171,27 @@ describe("apiRequest", () => {
         method: "POST",
         body: JSON.stringify({ note: "Internal note" })
       })
+    );
+  });
+
+  it("maps investigation timeline and summary requests to the transaction proxy", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(() => Promise.resolve(
+      new Response(JSON.stringify({ content: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      })
+    ));
+
+    await getInvestigationTimeline({ userId: "customer", transactionId: "txn-1", accountId: "101", alertId: "alert-1", caseId: "case-1" });
+    await getInvestigationSummary({ userId: "customer", transactionId: "txn-1" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/transaction-api/api/investigations/timeline?size=50&sort=createdAt%2Cdesc&userId=customer&transactionId=txn-1&accountId=101&alertId=alert-1&caseId=case-1",
+      expect.any(Object)
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/transaction-api/api/investigations/summary?userId=customer&transactionId=txn-1",
+      expect.any(Object)
     );
   });
 });

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -1,4 +1,4 @@
-import type { Account, AuditLogEntry, AuditSummary, Limits, Page, RiskAlert, RiskCase, RiskCaseSummary, RiskSummary, Transaction, TransactionStats } from "../types";
+import type { Account, AuditLogEntry, AuditSummary, InvestigationSummary, InvestigationTimelineItem, Limits, Page, RiskAlert, RiskCase, RiskCaseSummary, RiskSummary, Transaction, TransactionStats } from "../types";
 import { apiRequest, toQuery } from "./api";
 import type { AccountValues, LoginValues, MoneyMovementValues, RegisterValues, ReversalValues, TransferValues } from "./schemas";
 import { getSession } from "./session";
@@ -182,4 +182,12 @@ export function updateRiskCaseStatus(caseId: string, values: { status: string; r
 
 export function addRiskCaseNote(caseId: string, values: { note: string }) {
   return apiRequest<RiskCase>("transaction", `/api/risk/cases/${caseId}/notes`, { method: "POST", body: values });
+}
+
+export function getInvestigationTimeline(params: Record<string, string | number | undefined>) {
+  return apiRequest<Page<InvestigationTimelineItem>>("transaction", `/api/investigations/timeline${toQuery({ size: 50, sort: "createdAt,desc", ...params })}`);
+}
+
+export function getInvestigationSummary(params: Record<string, string | undefined> = {}) {
+  return apiRequest<InvestigationSummary>("transaction", `/api/investigations/summary${toQuery(params)}`);
 }

--- a/frontend/src/pages/AdminInvestigationsPage.tsx
+++ b/frontend/src/pages/AdminInvestigationsPage.tsx
@@ -1,0 +1,182 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import type { Dispatch, SetStateAction } from "react";
+import { useState } from "react";
+import { Badge, Button, EmptyState, Input, Panel, Stat } from "../components/ui";
+import { getInvestigationSummary, getInvestigationTimeline } from "../lib/queries";
+import type { InvestigationItemType, InvestigationTimelineItem } from "../types";
+
+const defaultFilters = {
+  userId: "",
+  transactionId: "",
+  accountId: "",
+  alertId: "",
+  caseId: "",
+  from: "",
+  to: ""
+};
+
+export function AdminInvestigationsPage() {
+  const [filters, setFilters] = useState(defaultFilters);
+  const [selected, setSelected] = useState<InvestigationTimelineItem | null>(null);
+
+  const timeline = useQuery({ queryKey: ["investigation-timeline", filters], queryFn: () => getInvestigationTimeline(filters) });
+  const summary = useQuery({ queryKey: ["investigation-summary", filters], queryFn: () => getInvestigationSummary(filters) });
+  const groupedItems = groupTimeline(timeline.data?.content || []);
+
+  return (
+    <div className="grid gap-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Investigations</h1>
+        <p className="text-sm text-muted">Read-only timeline for transaction, audit, risk alert, and case context.</p>
+      </div>
+
+      <Panel title="Search context">
+        <div className="grid gap-2 md:grid-cols-4 xl:grid-cols-7">
+          <Input placeholder="User ID" value={filters.userId} onChange={(event) => updateFilter(setFilters, "userId", event.target.value)} />
+          <Input placeholder="Transaction ID" value={filters.transactionId} onChange={(event) => updateFilter(setFilters, "transactionId", event.target.value)} />
+          <Input placeholder="Account ID" value={filters.accountId} onChange={(event) => updateFilter(setFilters, "accountId", event.target.value)} />
+          <Input placeholder="Alert ID" value={filters.alertId} onChange={(event) => updateFilter(setFilters, "alertId", event.target.value)} />
+          <Input placeholder="Case ID" value={filters.caseId} onChange={(event) => updateFilter(setFilters, "caseId", event.target.value)} />
+          <Input type="datetime-local" aria-label="From" value={filters.from} onChange={(event) => updateFilter(setFilters, "from", event.target.value)} />
+          <Input type="datetime-local" aria-label="To" value={filters.to} onChange={(event) => updateFilter(setFilters, "to", event.target.value)} />
+        </div>
+      </Panel>
+
+      <div className="grid gap-3 md:grid-cols-4 xl:grid-cols-7">
+        <Stat label="Transactions" value={formatNumber(summary.data?.transactions)} />
+        <Stat label="Audit events" value={formatNumber(summary.data?.auditEvents)} />
+        <Stat label="Risk alerts" value={formatNumber(summary.data?.riskAlerts)} />
+        <Stat label="Risk cases" value={formatNumber(summary.data?.riskCases)} />
+        <Stat label="Failures" value={<Badge tone={summary.data?.failures ? "bad" : "good"}>{formatNumber(summary.data?.failures)}</Badge>} />
+        <Stat label="Reversals" value={formatNumber(summary.data?.reversals)} />
+        <Stat label="High severity" value={<Badge tone={summary.data?.highSeverityItems ? "bad" : "neutral"}>{formatNumber(summary.data?.highSeverityItems)}</Badge>} />
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[1fr_430px]">
+        <Panel title="Timeline">
+          {timeline.error instanceof Error ? <p className="text-sm text-danger">{timeline.error.message}</p> : null}
+          {timeline.isLoading ? <p className="text-sm text-muted">Loading investigation timeline...</p> : null}
+          {!timeline.isLoading && !timeline.data?.content.length ? (
+            <EmptyState title="No timeline items found" detail="Search by user, transaction, account, alert, or case identifiers." />
+          ) : null}
+          <div className="grid gap-5">
+            {groupedItems.map((group) => (
+              <div key={group.label} className="grid gap-2">
+                <p className="text-xs font-semibold uppercase text-muted">{group.label}</p>
+                {group.items.map((item) => (
+                  <TimelineRow key={`${item.itemType}-${item.itemId}`} item={item} onSelect={() => setSelected(item)} />
+                ))}
+              </div>
+            ))}
+          </div>
+        </Panel>
+
+        <Panel title="Item detail" action={selected ? <Button variant="secondary" onClick={() => setSelected(null)}>Clear</Button> : null}>
+          {selected ? <TimelineDetail item={selected} /> : <EmptyState title="No item selected" detail="Select a timeline item to inspect linked identifiers and metadata." />}
+        </Panel>
+      </div>
+    </div>
+  );
+}
+
+function TimelineRow({ item, onSelect }: { item: InvestigationTimelineItem; onSelect: () => void }) {
+  return (
+    <div className="grid gap-3 border-b border-line pb-3 last:border-0 md:grid-cols-[160px_1fr_auto]">
+      <div className="text-xs text-muted">{formatDate(item.createdAt)}</div>
+      <div className="grid gap-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge tone={toneForType(item.itemType)}>{item.itemType}</Badge>
+          {item.severity ? <Badge tone={toneForSeverity(item.severity)}>{item.severity}</Badge> : null}
+          {item.status ? <Badge tone="neutral">{item.status}</Badge> : null}
+        </div>
+        <p className="text-sm font-medium text-ink">{item.title}</p>
+        {item.description ? <p className="text-sm text-muted">{item.description}</p> : null}
+        <p className="font-mono text-xs text-muted">{[item.userId, item.transactionId, item.accountId].filter(Boolean).join(" / ") || item.itemId}</p>
+      </div>
+      <div className="text-right">
+        <Button variant="secondary" onClick={onSelect}>View {item.itemId}</Button>
+      </div>
+    </div>
+  );
+}
+
+function TimelineDetail({ item }: { item: InvestigationTimelineItem }) {
+  const rows = [
+    ["Type", item.itemType],
+    ["Title", item.title],
+    ["Status", item.status],
+    ["Severity", item.severity],
+    ["User", item.userId],
+    ["Transaction", item.transactionId],
+    ["Account", item.accountId],
+    ["Alert", item.alertId],
+    ["Case", item.caseId],
+    ["Amount", item.amount && item.currency ? `${item.amount} ${item.currency}` : item.amount],
+    ["Created", formatDate(item.createdAt)]
+  ];
+
+  return (
+    <div className="grid gap-4">
+      <dl className="grid gap-3">
+        {rows.map(([label, value]) => (
+          <div key={label} className="rounded-md border border-line bg-white p-3">
+            <dt className="text-xs font-medium uppercase text-muted">{label}</dt>
+            <dd className="mt-1 break-words text-sm font-medium text-ink">{value || "n/a"}</dd>
+          </div>
+        ))}
+      </dl>
+      {item.description ? <p className="text-sm text-muted">{item.description}</p> : null}
+      <div className="flex flex-wrap gap-2">
+        {item.alertId ? <Link className="inline-flex h-9 items-center rounded-md border border-line bg-white px-3 text-sm font-medium text-ink hover:bg-slate-50" to="/admin/risk-alerts">Open alert</Link> : null}
+        {item.caseId ? <Link className="inline-flex h-9 items-center rounded-md border border-line bg-white px-3 text-sm font-medium text-ink hover:bg-slate-50" to="/admin/risk-cases">Open case</Link> : null}
+      </div>
+      <div className="rounded-md border border-line bg-white p-3">
+        <p className="text-xs font-medium uppercase text-muted">Metadata</p>
+        <dl className="mt-2 grid gap-2 text-sm">
+          {Object.entries(item.metadata || {}).length ? Object.entries(item.metadata || {}).map(([key, value]) => (
+            <div key={key} className="grid gap-1">
+              <dt className="font-medium text-ink">{key}</dt>
+              <dd className="break-words text-muted">{String(value)}</dd>
+            </div>
+          )) : <p className="text-sm text-muted">No metadata</p>}
+        </dl>
+      </div>
+    </div>
+  );
+}
+
+function groupTimeline(items: InvestigationTimelineItem[]) {
+  const groups = new Map<string, InvestigationTimelineItem[]>();
+  items.forEach((item) => {
+    const label = item.createdAt ? new Date(item.createdAt).toLocaleDateString() : "Unknown date";
+    groups.set(label, [...(groups.get(label) || []), item]);
+  });
+  return Array.from(groups.entries()).map(([label, groupItems]) => ({ label, items: groupItems }));
+}
+
+function updateFilter(setFilters: Dispatch<SetStateAction<typeof defaultFilters>>, key: keyof typeof defaultFilters, value: string) {
+  setFilters((prev) => ({ ...prev, [key]: value }));
+}
+
+function toneForType(type: InvestigationItemType): "neutral" | "good" | "warn" | "bad" | "info" {
+  if (type === "RISK_ALERT") return "bad";
+  if (type === "RISK_CASE") return "warn";
+  if (type === "CASE_NOTE") return "info";
+  if (type === "AUDIT_EVENT") return "neutral";
+  return "good";
+}
+
+function toneForSeverity(severity: string): "neutral" | "good" | "warn" | "bad" | "info" {
+  if (severity === "HIGH" || severity === "CRITICAL") return "bad";
+  if (severity === "MEDIUM") return "warn";
+  return "neutral";
+}
+
+function formatNumber(value: number | undefined) {
+  return String(value ?? 0);
+}
+
+function formatDate(value: string | undefined) {
+  return value ? new Date(value).toLocaleString() : "n/a";
+}

--- a/frontend/src/test/app.component.test.tsx
+++ b/frontend/src/test/app.component.test.tsx
@@ -98,6 +98,12 @@ function mockFetch(handler?: (url: string, init?: RequestInit) => Promise<Respon
     if (url.includes("/api/risk/cases")) {
       return jsonResponse(emptyPage);
     }
+    if (url.includes("/api/investigations/summary")) {
+      return jsonResponse({ transactions: 0, auditEvents: 0, riskAlerts: 0, riskCases: 0, failures: 0, reversals: 0, highSeverityItems: 0 });
+    }
+    if (url.includes("/api/investigations/timeline")) {
+      return jsonResponse(emptyPage);
+    }
     if (url.includes("/api/risk/alerts")) {
       return jsonResponse(emptyPage);
     }
@@ -232,6 +238,7 @@ describe("admin navigation", () => {
     expect(screen.getByRole("link", { name: "Audit Log" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Risk Alerts" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Risk Cases" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Investigations" })).toBeInTheDocument();
   });
 
   it("redirects non-admin users away from admin routes", async () => {
@@ -492,6 +499,87 @@ describe("admin risk cases", () => {
         && String(init.body).includes("Reviewed and resolved")
       )).toBe(true);
     });
+  });
+});
+
+describe("admin investigations", () => {
+  it("renders summary, search controls, timeline items, and selected item details", async () => {
+    const user = userEvent.setup();
+    const { calls } = mockFetch((url) => {
+      if (url.includes("/api/investigations/summary")) {
+        return jsonResponse({ transactions: 2, auditEvents: 2, riskAlerts: 1, riskCases: 1, failures: 1, reversals: 1, highSeverityItems: 2 });
+      }
+      if (url.includes("/api/investigations/timeline")) {
+        return jsonResponse({
+          ...emptyPage,
+          size: 50,
+          content: [
+            {
+              itemId: "alert-1",
+              itemType: "RISK_ALERT",
+              title: "HIGH_VALUE_TRANSFER",
+              description: "Transfer amount exceeded threshold",
+              severity: "HIGH",
+              status: "OPEN",
+              userId: "customer",
+              transactionId: "txn-1",
+              accountId: "101",
+              alertId: "alert-1",
+              amount: "6000.00",
+              currency: "USD",
+              createdAt: "2026-05-10T10:02:00",
+              metadata: { recommendation: "Review sender and recipient" }
+            },
+            {
+              itemId: "case-1",
+              itemType: "RISK_CASE",
+              title: "RC-20260510-0001",
+              description: "Review high value transfer",
+              severity: "HIGH",
+              status: "OPEN",
+              userId: "customer",
+              transactionId: "txn-1",
+              alertId: "alert-1",
+              caseId: "case-1",
+              createdAt: "2026-05-10T10:03:00",
+              metadata: { assignedTo: "ops" }
+            }
+          ],
+          totalElements: 2,
+          totalPages: 1
+        });
+      }
+      return undefined;
+    });
+
+    renderApp("/admin/investigations", tokenFor({ sub: "ops", roles: ["ROLE_ADMIN"] }));
+
+    expect(await screen.findByRole("heading", { name: "Investigations" })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getAllByText("2").length).toBeGreaterThan(0));
+    expect(screen.getByText("HIGH_VALUE_TRANSFER")).toBeInTheDocument();
+    expect(screen.getByText("RC-20260510-0001")).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText("User ID"), "customer");
+    await user.type(screen.getByPlaceholderText("Transaction ID"), "txn-1");
+    await user.type(screen.getByPlaceholderText("Account ID"), "101");
+    await user.type(screen.getByPlaceholderText("Alert ID"), "alert-1");
+    await user.type(screen.getByPlaceholderText("Case ID"), "case-1");
+
+    await waitFor(() => {
+      expect(calls.some(({ url }) =>
+        url.includes("/transaction-api/api/investigations/timeline")
+        && url.includes("userId=customer")
+        && url.includes("transactionId=txn-1")
+        && url.includes("accountId=101")
+        && url.includes("alertId=alert-1")
+        && url.includes("caseId=case-1")
+      )).toBe(true);
+    });
+
+    await user.click(screen.getByRole("button", { name: "View alert-1" }));
+    expect(screen.getAllByText("Transfer amount exceeded threshold").length).toBeGreaterThan(0);
+    expect(screen.getByText("Review sender and recipient")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open alert" })).toHaveAttribute("href", "/admin/risk-alerts");
   });
 });
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -180,3 +180,33 @@ export type RiskCaseSummary = {
   closedCases: number;
   unassignedCases: number;
 };
+
+export type InvestigationItemType = "TRANSACTION" | "AUDIT_EVENT" | "RISK_ALERT" | "RISK_CASE" | "CASE_NOTE";
+
+export type InvestigationTimelineItem = {
+  itemId: string;
+  itemType: InvestigationItemType;
+  title: string;
+  description?: string;
+  severity?: string;
+  status?: string;
+  userId?: string;
+  transactionId?: string;
+  accountId?: string;
+  alertId?: string;
+  caseId?: string;
+  amount?: string;
+  currency?: string;
+  createdAt: string;
+  metadata?: Record<string, unknown>;
+};
+
+export type InvestigationSummary = {
+  transactions: number;
+  auditEvents: number;
+  riskAlerts: number;
+  riskCases: number;
+  failures: number;
+  reversals: number;
+  highSeverityItems: number;
+};

--- a/frontend/tests/e2e/admin.spec.ts
+++ b/frontend/tests/e2e/admin.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-const adminUsername = process.env.E2E_ADMIN_USERNAME ?? "admin_phase2_212714";
+const adminUsername = process.env.E2E_ADMIN_USERNAME ?? "demo_admin";
 const adminPassword = process.env.E2E_ADMIN_PASSWORD ?? "password123";
 const customerPassword = "password123";
 

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/controller/InvestigationController.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/controller/InvestigationController.java
@@ -1,0 +1,65 @@
+package com.suhasan.finance.transaction_service.controller;
+
+import com.suhasan.finance.transaction_service.dto.InvestigationFilter;
+import com.suhasan.finance.transaction_service.dto.InvestigationSummaryResponse;
+import com.suhasan.finance.transaction_service.dto.InvestigationTimelineItemResponse;
+import com.suhasan.finance.transaction_service.service.InvestigationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+@RestController
+@RequestMapping("/api/investigations")
+@RequiredArgsConstructor
+public class InvestigationController {
+
+    private final InvestigationService investigationService;
+
+    @GetMapping("/timeline")
+    public ResponseEntity<Page<InvestigationTimelineItemResponse>> getTimeline(
+            @RequestParam(required = false) String userId,
+            @RequestParam(required = false) String transactionId,
+            @RequestParam(required = false) String accountId,
+            @RequestParam(required = false) String alertId,
+            @RequestParam(required = false) String caseId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
+            @PageableDefault(size = 50, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(investigationService.getTimeline(toFilter(userId, transactionId, accountId, alertId, caseId, from, to), pageable));
+    }
+
+    @GetMapping("/summary")
+    public ResponseEntity<InvestigationSummaryResponse> getSummary(
+            @RequestParam(required = false) String userId,
+            @RequestParam(required = false) String transactionId,
+            @RequestParam(required = false) String accountId,
+            @RequestParam(required = false) String alertId,
+            @RequestParam(required = false) String caseId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to) {
+        return ResponseEntity.ok(investigationService.getSummary(toFilter(userId, transactionId, accountId, alertId, caseId, from, to)));
+    }
+
+    private InvestigationFilter toFilter(String userId, String transactionId, String accountId, String alertId, String caseId,
+                                         LocalDateTime from, LocalDateTime to) {
+        return InvestigationFilter.builder()
+                .userId(userId)
+                .transactionId(transactionId)
+                .accountId(accountId)
+                .alertId(alertId)
+                .caseId(caseId)
+                .from(from)
+                .to(to)
+                .build();
+    }
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/InvestigationFilter.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/InvestigationFilter.java
@@ -1,0 +1,22 @@
+package com.suhasan.finance.transaction_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InvestigationFilter {
+    private String userId;
+    private String transactionId;
+    private String accountId;
+    private String alertId;
+    private String caseId;
+    private LocalDateTime from;
+    private LocalDateTime to;
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/InvestigationSummaryResponse.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/InvestigationSummaryResponse.java
@@ -1,0 +1,16 @@
+package com.suhasan.finance.transaction_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class InvestigationSummaryResponse {
+    private long transactions;
+    private long auditEvents;
+    private long riskAlerts;
+    private long riskCases;
+    private long failures;
+    private long reversals;
+    private long highSeverityItems;
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/InvestigationTimelineItemResponse.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/InvestigationTimelineItemResponse.java
@@ -1,0 +1,31 @@
+package com.suhasan.finance.transaction_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class InvestigationTimelineItemResponse {
+    private String itemId;
+    private String itemType;
+    private String title;
+    private String description;
+    private String severity;
+    private String status;
+    private String userId;
+    private String transactionId;
+    private String accountId;
+    private String alertId;
+    private String caseId;
+    private String amount;
+    private String currency;
+    private LocalDateTime createdAt;
+    private Map<String, Object> metadata;
+}

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/repository/TransactionRepository.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/repository/TransactionRepository.java
@@ -6,6 +6,7 @@ import com.suhasan.finance.transaction_service.entity.TransactionType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,7 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface TransactionRepository extends JpaRepository<Transaction, String>, TransactionRepositoryCustom {
+public interface TransactionRepository extends JpaRepository<Transaction, String>, JpaSpecificationExecutor<Transaction>, TransactionRepositoryCustom {
 
        // Find transactions by account
        Page<Transaction> findByFromAccountIdOrToAccountIdOrderByCreatedAtDesc(

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/security/SecurityConfig.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/security/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/monitoring/**").hasAnyRole("ADMIN", "INTERNAL_SERVICE")
                         .requestMatchers("/api/audit/**").hasAnyRole("ADMIN", "INTERNAL_SERVICE")
                         .requestMatchers("/api/risk/**").hasAnyRole("ADMIN", "INTERNAL_SERVICE")
+                        .requestMatchers("/api/investigations/**").hasAnyRole("ADMIN", "INTERNAL_SERVICE")
 
                         // ── Transaction endpoints — require authenticated user ────────────────
                         .requestMatchers("/api/transactions/**").authenticated()

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/service/InvestigationService.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/service/InvestigationService.java
@@ -1,0 +1,361 @@
+package com.suhasan.finance.transaction_service.service;
+
+import com.suhasan.finance.transaction_service.dto.InvestigationFilter;
+import com.suhasan.finance.transaction_service.dto.InvestigationSummaryResponse;
+import com.suhasan.finance.transaction_service.dto.InvestigationTimelineItemResponse;
+import com.suhasan.finance.transaction_service.entity.AuditLogEntry;
+import com.suhasan.finance.transaction_service.entity.RiskAlert;
+import com.suhasan.finance.transaction_service.entity.RiskAlertSeverity;
+import com.suhasan.finance.transaction_service.entity.RiskCase;
+import com.suhasan.finance.transaction_service.entity.RiskCaseNote;
+import com.suhasan.finance.transaction_service.entity.RiskCasePriority;
+import com.suhasan.finance.transaction_service.entity.Transaction;
+import com.suhasan.finance.transaction_service.entity.TransactionStatus;
+import com.suhasan.finance.transaction_service.entity.TransactionType;
+import com.suhasan.finance.transaction_service.repository.AuditLogEntryRepository;
+import com.suhasan.finance.transaction_service.repository.RiskAlertRepository;
+import com.suhasan.finance.transaction_service.repository.RiskCaseRepository;
+import com.suhasan.finance.transaction_service.repository.TransactionRepository;
+import jakarta.persistence.criteria.Predicate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class InvestigationService {
+
+    private final TransactionRepository transactionRepository;
+    private final AuditLogEntryRepository auditLogEntryRepository;
+    private final RiskAlertRepository riskAlertRepository;
+    private final RiskCaseRepository riskCaseRepository;
+
+    @Transactional(readOnly = true)
+    public Page<InvestigationTimelineItemResponse> getTimeline(InvestigationFilter filter, Pageable pageable) {
+        InvestigationContext context = resolveContext(filter);
+        if (!context.hasCriteria()) {
+            return Page.empty(pageable);
+        }
+        List<InvestigationTimelineItemResponse> items = collectItems(context);
+        items.sort(Comparator.comparing(InvestigationTimelineItemResponse::getCreatedAt,
+                Comparator.nullsLast(Comparator.naturalOrder())).reversed());
+        int start = (int) Math.min(pageable.getOffset(), items.size());
+        int end = Math.min(start + pageable.getPageSize(), items.size());
+        return new PageImpl<>(items.subList(start, end), pageable, items.size());
+    }
+
+    @Transactional(readOnly = true)
+    public InvestigationSummaryResponse getSummary(InvestigationFilter filter) {
+        InvestigationContext context = resolveContext(filter);
+        if (!context.hasCriteria()) {
+            return new InvestigationSummaryResponse(0, 0, 0, 0, 0, 0, 0);
+        }
+        List<Transaction> transactions = transactionRepository.findAll(transactionSpec(context));
+        List<AuditLogEntry> audits = auditLogEntryRepository.findAll(auditSpec(context));
+        List<RiskAlert> alerts = riskAlertRepository.findAll(alertSpec(context));
+        List<RiskCase> cases = riskCaseRepository.findAll(caseSpec(context));
+
+        long failures = transactions.stream().filter(transaction -> transaction.getStatus() == TransactionStatus.FAILED).count()
+                + audits.stream().filter(audit -> "FAILURE".equalsIgnoreCase(audit.getOutcome())).count();
+        long reversals = transactions.stream().filter(transaction -> transaction.getType() == TransactionType.REVERSAL).count();
+        long highSeverity = alerts.stream().filter(alert -> alert.getSeverity() == RiskAlertSeverity.HIGH).count()
+                + cases.stream().filter(riskCase -> riskCase.getPriority() == RiskCasePriority.HIGH || riskCase.getPriority() == RiskCasePriority.CRITICAL).count();
+
+        return new InvestigationSummaryResponse(transactions.size(), audits.size(), alerts.size(), cases.size(), failures, reversals, highSeverity);
+    }
+
+    private List<InvestigationTimelineItemResponse> collectItems(InvestigationContext context) {
+        List<InvestigationTimelineItemResponse> items = new ArrayList<>();
+        transactionRepository.findAll(transactionSpec(context)).forEach(transaction -> items.add(toTransactionItem(transaction)));
+        auditLogEntryRepository.findAll(auditSpec(context)).forEach(audit -> items.add(toAuditItem(audit)));
+        riskAlertRepository.findAll(alertSpec(context)).forEach(alert -> items.add(toAlertItem(alert)));
+        riskCaseRepository.findAll(caseSpec(context)).forEach(riskCase -> {
+            items.add(toCaseItem(riskCase));
+            riskCase.getNotes().forEach(note -> items.add(toCaseNoteItem(riskCase, note)));
+        });
+        return items;
+    }
+
+    private InvestigationContext resolveContext(InvestigationFilter filter) {
+        InvestigationContext context = new InvestigationContext(filter);
+        if (hasText(filter.getCaseId())) {
+            riskCaseRepository.findById(filter.getCaseId()).ifPresent(riskCase -> {
+                context.caseIds.add(riskCase.getCaseId());
+                addIfPresent(context.userIds, riskCase.getUserId());
+                addIfPresent(context.transactionIds, riskCase.getTransactionId());
+                addIfPresent(context.alertIds, riskCase.getPrimaryAlertId());
+                riskCase.getLinkedAlerts().forEach(alert -> addIfPresent(context.alertIds, alert.getAlertId()));
+            });
+        }
+        if (hasText(filter.getAlertId())) {
+            riskAlertRepository.findById(filter.getAlertId()).ifPresent(alert -> {
+                context.alertIds.add(alert.getAlertId());
+                addIfPresent(context.userIds, alert.getUserId());
+                addIfPresent(context.transactionIds, alert.getTransactionId());
+                addIfPresent(context.accountIds, alert.getFromAccountId());
+                addIfPresent(context.accountIds, alert.getToAccountId());
+            });
+        }
+        return context;
+    }
+
+    private Specification<Transaction> transactionSpec(InvestigationContext context) {
+        return (root, query, cb) -> {
+            List<Predicate> criteria = new ArrayList<>();
+            if (!context.userIds.isEmpty()) {
+                criteria.add(root.get("createdBy").in(context.userIds));
+            }
+            if (!context.transactionIds.isEmpty()) {
+                criteria.add(root.get("transactionId").in(context.transactionIds));
+            }
+            if (!context.accountIds.isEmpty()) {
+                criteria.add(cb.or(root.get("fromAccountId").in(context.accountIds), root.get("toAccountId").in(context.accountIds)));
+            }
+            return withDateRange(context, anyMatch(criteria, cb), root.get("createdAt"), cb);
+        };
+    }
+
+    private Specification<AuditLogEntry> auditSpec(InvestigationContext context) {
+        return (root, query, cb) -> {
+            List<Predicate> criteria = new ArrayList<>();
+            if (!context.userIds.isEmpty()) {
+                criteria.add(root.get("userId").in(context.userIds));
+            }
+            if (!context.transactionIds.isEmpty()) {
+                criteria.add(root.get("transactionId").in(context.transactionIds));
+            }
+            if (!context.accountIds.isEmpty()) {
+                criteria.add(cb.or(root.get("fromAccountId").in(context.accountIds), root.get("toAccountId").in(context.accountIds)));
+            }
+            return withDateRange(context, anyMatch(criteria, cb), root.get("createdAt"), cb);
+        };
+    }
+
+    private Specification<RiskAlert> alertSpec(InvestigationContext context) {
+        return (root, query, cb) -> {
+            List<Predicate> criteria = new ArrayList<>();
+            if (!context.alertIds.isEmpty()) {
+                criteria.add(root.get("alertId").in(context.alertIds));
+            }
+            if (!context.userIds.isEmpty()) {
+                criteria.add(root.get("userId").in(context.userIds));
+            }
+            if (!context.transactionIds.isEmpty()) {
+                criteria.add(root.get("transactionId").in(context.transactionIds));
+            }
+            if (!context.accountIds.isEmpty()) {
+                criteria.add(cb.or(root.get("fromAccountId").in(context.accountIds), root.get("toAccountId").in(context.accountIds)));
+            }
+            return withDateRange(context, anyMatch(criteria, cb), root.get("createdAt"), cb);
+        };
+    }
+
+    private Specification<RiskCase> caseSpec(InvestigationContext context) {
+        return (root, query, cb) -> {
+            List<Predicate> criteria = new ArrayList<>();
+            if (!context.caseIds.isEmpty()) {
+                criteria.add(root.get("caseId").in(context.caseIds));
+            }
+            if (!context.alertIds.isEmpty()) {
+                criteria.add(root.get("primaryAlertId").in(context.alertIds));
+            }
+            if (!context.userIds.isEmpty()) {
+                criteria.add(root.get("userId").in(context.userIds));
+            }
+            if (!context.transactionIds.isEmpty()) {
+                criteria.add(root.get("transactionId").in(context.transactionIds));
+            }
+            return withDateRange(context, anyMatch(criteria, cb), root.get("createdAt"), cb);
+        };
+    }
+
+    private Predicate anyMatch(List<Predicate> criteria, jakarta.persistence.criteria.CriteriaBuilder cb) {
+        if (criteria.isEmpty()) {
+            return cb.disjunction();
+        }
+        return cb.or(criteria.toArray(Predicate[]::new));
+    }
+
+    private Predicate withDateRange(InvestigationContext context, Predicate criteria, jakarta.persistence.criteria.Path<LocalDateTime> path,
+                                    jakarta.persistence.criteria.CriteriaBuilder cb) {
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(criteria);
+        if (context.from != null) {
+            predicates.add(cb.greaterThanOrEqualTo(path, context.from));
+        }
+        if (context.to != null) {
+            predicates.add(cb.lessThanOrEqualTo(path, context.to));
+        }
+        return cb.and(predicates.toArray(Predicate[]::new));
+    }
+
+    private InvestigationTimelineItemResponse toTransactionItem(Transaction transaction) {
+        return InvestigationTimelineItemResponse.builder()
+                .itemId(transaction.getTransactionId())
+                .itemType("TRANSACTION")
+                .title(transaction.getType() + " " + transaction.getStatus())
+                .description(transaction.getDescription())
+                .status(name(transaction.getStatus()))
+                .userId(transaction.getCreatedBy())
+                .transactionId(transaction.getTransactionId())
+                .accountId(firstNonBlank(transaction.getFromAccountId(), transaction.getToAccountId()))
+                .amount(amount(transaction.getAmount()))
+                .currency(transaction.getCurrency())
+                .createdAt(transaction.getCreatedAt())
+                .metadata(metadata(
+                        "type", name(transaction.getType()),
+                        "fromAccountId", transaction.getFromAccountId(),
+                        "toAccountId", transaction.getToAccountId(),
+                        "reference", transaction.getReference(),
+                        "processingState", name(transaction.getProcessingState())))
+                .build();
+    }
+
+    private InvestigationTimelineItemResponse toAuditItem(AuditLogEntry audit) {
+        return InvestigationTimelineItemResponse.builder()
+                .itemId(audit.getEventId())
+                .itemType("AUDIT_EVENT")
+                .title(audit.getAction() + " " + audit.getOutcome())
+                .description(firstNonBlank(audit.getDetails(), audit.getErrorMessage()))
+                .status(audit.getOutcome())
+                .userId(audit.getUserId())
+                .transactionId(audit.getTransactionId())
+                .accountId(firstNonBlank(audit.getFromAccountId(), audit.getToAccountId()))
+                .amount(amount(audit.getAmount()))
+                .currency(audit.getCurrency())
+                .createdAt(audit.getCreatedAt())
+                .metadata(metadata(
+                        "eventType", audit.getEventType(),
+                        "errorCode", audit.getErrorCode(),
+                        "errorMessage", audit.getErrorMessage(),
+                        "metadata", audit.getMetadata()))
+                .build();
+    }
+
+    private InvestigationTimelineItemResponse toAlertItem(RiskAlert alert) {
+        return InvestigationTimelineItemResponse.builder()
+                .itemId(alert.getAlertId())
+                .itemType("RISK_ALERT")
+                .title(alert.getAlertType().name())
+                .description(alert.getReason())
+                .severity(name(alert.getSeverity()))
+                .status(name(alert.getStatus()))
+                .userId(alert.getUserId())
+                .transactionId(alert.getTransactionId())
+                .accountId(firstNonBlank(alert.getFromAccountId(), alert.getToAccountId()))
+                .alertId(alert.getAlertId())
+                .amount(amount(alert.getAmount()))
+                .currency(alert.getCurrency())
+                .createdAt(alert.getCreatedAt())
+                .metadata(metadata(
+                        "recommendation", alert.getRecommendation(),
+                        "dedupeKey", alert.getDedupeKey(),
+                        "metadata", alert.getMetadata()))
+                .build();
+    }
+
+    private InvestigationTimelineItemResponse toCaseItem(RiskCase riskCase) {
+        return InvestigationTimelineItemResponse.builder()
+                .itemId(riskCase.getCaseId())
+                .itemType("RISK_CASE")
+                .title(riskCase.getCaseNumber())
+                .description(riskCase.getTitle())
+                .severity(name(riskCase.getPriority()))
+                .status(name(riskCase.getStatus()))
+                .userId(riskCase.getUserId())
+                .transactionId(riskCase.getTransactionId())
+                .alertId(riskCase.getPrimaryAlertId())
+                .caseId(riskCase.getCaseId())
+                .createdAt(riskCase.getCreatedAt())
+                .metadata(metadata(
+                        "assignedTo", riskCase.getAssignedTo(),
+                        "createdBy", riskCase.getCreatedBy(),
+                        "resolutionNote", riskCase.getResolutionNote()))
+                .build();
+    }
+
+    private InvestigationTimelineItemResponse toCaseNoteItem(RiskCase riskCase, RiskCaseNote note) {
+        return InvestigationTimelineItemResponse.builder()
+                .itemId(note.getNoteId())
+                .itemType("CASE_NOTE")
+                .title("Case note")
+                .description(note.getNote())
+                .userId(riskCase.getUserId())
+                .transactionId(riskCase.getTransactionId())
+                .alertId(riskCase.getPrimaryAlertId())
+                .caseId(riskCase.getCaseId())
+                .createdAt(note.getCreatedAt())
+                .metadata(metadata("author", note.getAuthor(), "caseNumber", riskCase.getCaseNumber()))
+                .build();
+    }
+
+    private Map<String, Object> metadata(Object... values) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        for (int i = 0; i + 1 < values.length; i += 2) {
+            if (values[i + 1] != null) {
+                metadata.put(String.valueOf(values[i]), values[i + 1]);
+            }
+        }
+        return metadata;
+    }
+
+    private String amount(BigDecimal amount) {
+        return amount != null ? amount.toPlainString() : null;
+    }
+
+    private String name(Enum<?> value) {
+        return value != null ? value.name() : null;
+    }
+
+    private String firstNonBlank(String first, String second) {
+        return hasText(first) ? first : second;
+    }
+
+    private void addIfPresent(Set<String> values, String value) {
+        if (hasText(value)) {
+            values.add(value);
+        }
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private class InvestigationContext {
+        private final Set<String> userIds = new HashSet<>();
+        private final Set<String> transactionIds = new HashSet<>();
+        private final Set<String> accountIds = new HashSet<>();
+        private final Set<String> alertIds = new HashSet<>();
+        private final Set<String> caseIds = new HashSet<>();
+        private final LocalDateTime from;
+        private final LocalDateTime to;
+
+        private InvestigationContext(InvestigationFilter filter) {
+            addIfPresent(userIds, filter.getUserId());
+            addIfPresent(transactionIds, filter.getTransactionId());
+            addIfPresent(accountIds, filter.getAccountId());
+            addIfPresent(alertIds, filter.getAlertId());
+            addIfPresent(caseIds, filter.getCaseId());
+            this.from = filter.getFrom();
+            this.to = filter.getTo();
+        }
+
+        private boolean hasCriteria() {
+            return !userIds.isEmpty() || !transactionIds.isEmpty() || !accountIds.isEmpty() || !alertIds.isEmpty() || !caseIds.isEmpty();
+        }
+    }
+}

--- a/transaction-service/src/test/java/com/suhasan/finance/transaction_service/controller/InvestigationControllerTest.java
+++ b/transaction-service/src/test/java/com/suhasan/finance/transaction_service/controller/InvestigationControllerTest.java
@@ -1,0 +1,133 @@
+package com.suhasan.finance.transaction_service.controller;
+
+import com.suhasan.finance.transaction_service.dto.InvestigationFilter;
+import com.suhasan.finance.transaction_service.dto.InvestigationSummaryResponse;
+import com.suhasan.finance.transaction_service.dto.InvestigationTimelineItemResponse;
+import com.suhasan.finance.transaction_service.security.JwtAuthenticationFilter;
+import com.suhasan.finance.transaction_service.service.InvestigationService;
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(InvestigationController.class)
+@Import(com.suhasan.finance.transaction_service.security.SecurityConfig.class)
+@EnableWebSecurity
+class InvestigationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private InvestigationService investigationService;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUpFilter() throws Exception {
+        doAnswer(invocation -> {
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void timeline_AllowsAdminAndPassesSearchFilters() throws Exception {
+        InvestigationTimelineItemResponse item = InvestigationTimelineItemResponse.builder()
+                .itemId("txn-1")
+                .itemType("TRANSACTION")
+                .title("TRANSFER COMPLETED")
+                .description("High value transfer")
+                .status("COMPLETED")
+                .userId("customer")
+                .transactionId("txn-1")
+                .accountId("101")
+                .amount("6000.00")
+                .currency("USD")
+                .createdAt(LocalDateTime.parse("2026-05-10T10:15:30"))
+                .metadata(Map.of("type", "TRANSFER"))
+                .build();
+        Page<InvestigationTimelineItemResponse> page = new PageImpl<>(List.of(item), PageRequest.of(0, 50), 1);
+        when(investigationService.getTimeline(any(), any())).thenReturn(page);
+
+        mockMvc.perform(get("/api/investigations/timeline")
+                        .param("userId", "customer")
+                        .param("transactionId", "txn-1")
+                        .param("accountId", "101")
+                        .param("alertId", "alert-1")
+                        .param("caseId", "case-1")
+                        .param("from", "2026-05-01T00:00:00")
+                        .param("to", "2026-05-11T00:00:00"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].itemType").value("TRANSACTION"))
+                .andExpect(jsonPath("$.content[0].transactionId").value("txn-1"))
+                .andExpect(jsonPath("$.content[0].accountId").value("101"))
+                .andExpect(jsonPath("$.totalElements").value(1));
+
+        verify(investigationService).getTimeline(argThat(filter ->
+                        "customer".equals(filter.getUserId())
+                                && "txn-1".equals(filter.getTransactionId())
+                                && "101".equals(filter.getAccountId())
+                                && "alert-1".equals(filter.getAlertId())
+                                && "case-1".equals(filter.getCaseId())
+                                && LocalDateTime.parse("2026-05-01T00:00:00").equals(filter.getFrom())
+                                && LocalDateTime.parse("2026-05-11T00:00:00").equals(filter.getTo())),
+                any());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void timeline_RejectsNormalUsers() throws Exception {
+        mockMvc.perform(get("/api/investigations/timeline"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void summary_ReturnsInvestigationCounts() throws Exception {
+        when(investigationService.getSummary(any())).thenReturn(new InvestigationSummaryResponse(2, 3, 1, 1, 2, 1, 1));
+
+        mockMvc.perform(get("/api/investigations/summary")
+                        .param("caseId", "case-1")
+                        .param("from", "2026-05-01T00:00:00")
+                        .param("to", "2026-05-11T00:00:00"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.transactions").value(2))
+                .andExpect(jsonPath("$.auditEvents").value(3))
+                .andExpect(jsonPath("$.riskAlerts").value(1))
+                .andExpect(jsonPath("$.riskCases").value(1))
+                .andExpect(jsonPath("$.failures").value(2))
+                .andExpect(jsonPath("$.reversals").value(1))
+                .andExpect(jsonPath("$.highSeverityItems").value(1));
+
+        verify(investigationService).getSummary(argThat(filter ->
+                "case-1".equals(filter.getCaseId())
+                        && LocalDateTime.parse("2026-05-01T00:00:00").equals(filter.getFrom())
+                        && LocalDateTime.parse("2026-05-11T00:00:00").equals(filter.getTo())));
+    }
+}

--- a/transaction-service/src/test/java/com/suhasan/finance/transaction_service/service/InvestigationServiceTest.java
+++ b/transaction-service/src/test/java/com/suhasan/finance/transaction_service/service/InvestigationServiceTest.java
@@ -1,0 +1,228 @@
+package com.suhasan.finance.transaction_service.service;
+
+import com.suhasan.finance.transaction_service.dto.InvestigationFilter;
+import com.suhasan.finance.transaction_service.dto.InvestigationSummaryResponse;
+import com.suhasan.finance.transaction_service.dto.InvestigationTimelineItemResponse;
+import com.suhasan.finance.transaction_service.entity.AuditLogEntry;
+import com.suhasan.finance.transaction_service.entity.RiskAlert;
+import com.suhasan.finance.transaction_service.entity.RiskAlertSeverity;
+import com.suhasan.finance.transaction_service.entity.RiskAlertStatus;
+import com.suhasan.finance.transaction_service.entity.RiskAlertType;
+import com.suhasan.finance.transaction_service.entity.RiskCase;
+import com.suhasan.finance.transaction_service.entity.RiskCaseNote;
+import com.suhasan.finance.transaction_service.entity.RiskCasePriority;
+import com.suhasan.finance.transaction_service.entity.RiskCaseStatus;
+import com.suhasan.finance.transaction_service.entity.Transaction;
+import com.suhasan.finance.transaction_service.entity.TransactionStatus;
+import com.suhasan.finance.transaction_service.entity.TransactionType;
+import com.suhasan.finance.transaction_service.repository.AuditLogEntryRepository;
+import com.suhasan.finance.transaction_service.repository.RiskAlertRepository;
+import com.suhasan.finance.transaction_service.repository.RiskCaseRepository;
+import com.suhasan.finance.transaction_service.repository.TransactionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InvestigationServiceTest {
+
+    @Mock
+    private TransactionRepository transactionRepository;
+
+    @Mock
+    private AuditLogEntryRepository auditLogEntryRepository;
+
+    @Mock
+    private RiskAlertRepository riskAlertRepository;
+
+    @Mock
+    private RiskCaseRepository riskCaseRepository;
+
+    @InjectMocks
+    private InvestigationService investigationService;
+
+    @Test
+    void getTimeline_ExpandsCaseSearchAndReturnsMixedItemsNewestFirst() {
+        RiskAlert alert = alert();
+        RiskCase riskCase = riskCase(alert);
+        when(riskCaseRepository.findById("case-1")).thenReturn(Optional.of(riskCase));
+        when(transactionRepository.findAll(any(Specification.class))).thenReturn(List.of(transaction()));
+        when(auditLogEntryRepository.findAll(any(Specification.class))).thenReturn(List.of(audit()));
+        when(riskAlertRepository.findAll(any(Specification.class))).thenReturn(List.of(alert));
+        when(riskCaseRepository.findAll(any(Specification.class))).thenReturn(List.of(riskCase));
+
+        Page<InvestigationTimelineItemResponse> result = investigationService.getTimeline(
+                InvestigationFilter.builder().caseId("case-1").build(),
+                PageRequest.of(0, 50, Sort.by(Sort.Direction.DESC, "createdAt")));
+
+        assertThat(result.getTotalElements()).isEqualTo(5);
+        assertThat(result.getContent()).extracting(InvestigationTimelineItemResponse::getItemType)
+                .containsExactly("CASE_NOTE", "RISK_CASE", "RISK_ALERT", "AUDIT_EVENT", "TRANSACTION");
+        assertThat(result.getContent().get(0).getCaseId()).isEqualTo("case-1");
+        assertThat(result.getContent().get(2).getAlertId()).isEqualTo("alert-1");
+
+        ArgumentCaptor<Specification<Transaction>> transactionSpec = ArgumentCaptor.forClass(Specification.class);
+        verify(transactionRepository).findAll(transactionSpec.capture());
+    }
+
+    @Test
+    void getTimeline_EmptySearchReturnsEmptyPage() {
+        when(transactionRepository.findAll(any(Specification.class))).thenReturn(List.of());
+        when(auditLogEntryRepository.findAll(any(Specification.class))).thenReturn(List.of());
+        when(riskAlertRepository.findAll(any(Specification.class))).thenReturn(List.of());
+        when(riskCaseRepository.findAll(any(Specification.class))).thenReturn(List.of());
+
+        Page<InvestigationTimelineItemResponse> result = investigationService.getTimeline(
+                InvestigationFilter.builder().userId("missing").build(),
+                PageRequest.of(0, 50));
+
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+    }
+
+    @Test
+    void getSummary_CountsMixedSourcesAndHighSeverityItems() {
+        RiskAlert alert = alert();
+        RiskCase riskCase = riskCase(alert);
+        when(riskAlertRepository.findById("alert-1")).thenReturn(Optional.of(alert));
+        when(transactionRepository.findAll(any(Specification.class))).thenReturn(List.of(transaction(), reversal()));
+        when(auditLogEntryRepository.findAll(any(Specification.class))).thenReturn(List.of(audit(), failedAudit()));
+        when(riskAlertRepository.findAll(any(Specification.class))).thenReturn(List.of(alert));
+        when(riskCaseRepository.findAll(any(Specification.class))).thenReturn(List.of(riskCase));
+
+        InvestigationSummaryResponse summary = investigationService.getSummary(
+                InvestigationFilter.builder().alertId("alert-1").build());
+
+        assertThat(summary.getTransactions()).isEqualTo(2);
+        assertThat(summary.getAuditEvents()).isEqualTo(2);
+        assertThat(summary.getRiskAlerts()).isEqualTo(1);
+        assertThat(summary.getRiskCases()).isEqualTo(1);
+        assertThat(summary.getFailures()).isEqualTo(2);
+        assertThat(summary.getReversals()).isEqualTo(1);
+        assertThat(summary.getHighSeverityItems()).isEqualTo(2);
+    }
+
+    private Transaction transaction() {
+        return Transaction.builder()
+                .transactionId("txn-1")
+                .fromAccountId("101")
+                .toAccountId("202")
+                .amount(new BigDecimal("6000.00"))
+                .currency("USD")
+                .type(TransactionType.TRANSFER)
+                .status(TransactionStatus.COMPLETED)
+                .description("High value transfer")
+                .createdBy("customer")
+                .createdAt(LocalDateTime.parse("2026-05-10T10:00:00"))
+                .build();
+    }
+
+    private Transaction reversal() {
+        return Transaction.builder()
+                .transactionId("txn-2")
+                .fromAccountId("202")
+                .toAccountId("101")
+                .amount(new BigDecimal("6000.00"))
+                .currency("USD")
+                .type(TransactionType.REVERSAL)
+                .status(TransactionStatus.FAILED)
+                .createdBy("customer")
+                .createdAt(LocalDateTime.parse("2026-05-10T10:05:00"))
+                .build();
+    }
+
+    private AuditLogEntry audit() {
+        return AuditLogEntry.builder()
+                .eventId("audit-1")
+                .eventType("TRANSACTION_COMPLETED")
+                .action("TRANSFER")
+                .outcome("SUCCESS")
+                .userId("customer")
+                .transactionId("txn-1")
+                .fromAccountId("101")
+                .toAccountId("202")
+                .amount(new BigDecimal("6000.00"))
+                .currency("USD")
+                .details("Transfer completed")
+                .createdAt(LocalDateTime.parse("2026-05-10T10:01:00"))
+                .build();
+    }
+
+    private AuditLogEntry failedAudit() {
+        return AuditLogEntry.builder()
+                .eventId("audit-2")
+                .eventType("TRANSACTION_FAILED")
+                .action("REVERSAL")
+                .outcome("FAILURE")
+                .userId("customer")
+                .transactionId("txn-2")
+                .fromAccountId("202")
+                .toAccountId("101")
+                .details("Reversal failed")
+                .createdAt(LocalDateTime.parse("2026-05-10T10:06:00"))
+                .build();
+    }
+
+    private RiskAlert alert() {
+        return RiskAlert.builder()
+                .alertId("alert-1")
+                .alertType(RiskAlertType.HIGH_VALUE_TRANSFER)
+                .severity(RiskAlertSeverity.HIGH)
+                .status(RiskAlertStatus.OPEN)
+                .userId("customer")
+                .transactionId("txn-1")
+                .fromAccountId("101")
+                .toAccountId("202")
+                .amount(new BigDecimal("6000.00"))
+                .currency("USD")
+                .reason("Transfer amount exceeded threshold")
+                .recommendation("Review customer activity")
+                .dedupeKey("HIGH_VALUE_TRANSFER:txn-1")
+                .createdAt(LocalDateTime.parse("2026-05-10T10:02:00"))
+                .updatedAt(LocalDateTime.parse("2026-05-10T10:02:00"))
+                .build();
+    }
+
+    private RiskCase riskCase(RiskAlert alert) {
+        RiskCase riskCase = RiskCase.builder()
+                .caseId("case-1")
+                .caseNumber("RC-20260510-0001")
+                .status(RiskCaseStatus.OPEN)
+                .priority(RiskCasePriority.HIGH)
+                .title("Review high value transfer")
+                .userId("customer")
+                .transactionId("txn-1")
+                .primaryAlertId("alert-1")
+                .createdBy("ops")
+                .createdAt(LocalDateTime.parse("2026-05-10T10:03:00"))
+                .updatedAt(LocalDateTime.parse("2026-05-10T10:03:00"))
+                .linkedAlerts(List.of(alert))
+                .build();
+        RiskCaseNote note = RiskCaseNote.builder()
+                .noteId("note-1")
+                .riskCase(riskCase)
+                .author("ops")
+                .note("Initial review note")
+                .createdAt(LocalDateTime.parse("2026-05-10T10:04:00"))
+                .build();
+        riskCase.setNotes(List.of(note));
+        return riskCase;
+    }
+}

--- a/transaction-service/src/test/java/com/suhasan/finance/transaction_service/service/RiskCaseServiceTest.java
+++ b/transaction-service/src/test/java/com/suhasan/finance/transaction_service/service/RiskCaseServiceTest.java
@@ -22,7 +22,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,7 +67,7 @@ class RiskCaseServiceTest {
                 "ops");
 
         assertThat(response.getCaseId()).isEqualTo("case-1");
-        assertThat(response.getCaseNumber()).isEqualTo("RC-20260509-0008");
+        assertThat(response.getCaseNumber()).isEqualTo("RC-" + LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE) + "-0008");
         assertThat(response.getPriority()).isEqualTo(RiskCasePriority.HIGH);
         assertThat(response.getStatus()).isEqualTo(RiskCaseStatus.OPEN);
         assertThat(response.getPrimaryAlertId()).isEqualTo("alert-1");


### PR DESCRIPTION
## Summary

Adds a read-only admin investigation workspace in `transaction-service` and the React admin console. Admins can search by user, transaction, account, alert, or case identifiers and review related transactions, audit events, risk alerts, risk cases, and case notes in one timeline.

## Changes

- Added `GET /api/investigations/timeline` and `GET /api/investigations/summary` behind the same `ROLE_ADMIN` / `ROLE_INTERNAL_SERVICE` guard used by audit and risk APIs.
- Added investigation DTOs and service logic for case/alert context expansion, bounded timeline pagination, summary counters, mixed-source item mapping, and case note inclusion.
- Added the `Investigations` admin navigation item and `AdminInvestigationsPage` with search filters, counters, timeline grouping, detail metadata, and quick links to Risk Alerts / Risk Cases.
- Updated the existing README with the Investigation Timeline feature, API surface, access rules, read-only v1 behavior, and test coverage.

## Validation

- `cd transaction-service && .\mvnw.cmd -q test`
- `cd frontend && npm.cmd test`
- `cd frontend && npm.cmd run build`
- `cd frontend && npm.cmd run e2e`
- Optional: `cd account-service && .\mvnw.cmd -q test`

Note: GitHub CLI auth is stale locally, so this PR was opened through the GitHub connector after pushing the branch with Git credentials.