### PR TITLE
[codex] Add pending debit authorization holds

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ The backend provides account management, authentication, transaction processing,
 
 ```text
 financial-backend-services/
-├── account-service/          # Spring Boot account/auth service on port 8080
-├── transaction-service/      # Spring Boot transaction service on port 8081
-├── frontend/                 # React + Vite + TypeScript financial console
-├── docker-compose.codex.yml  # Local verification compose file used during this work
-├── .github/workflows/        # PR validation and CI checks
-└── README.md
+|-- account-service/          # Spring Boot account/auth service on port 8080
+|-- transaction-service/      # Spring Boot transaction service on port 8081
+|-- frontend/                 # React + Vite + TypeScript financial console
+|-- docker-compose.codex.yml  # Local verification compose file used during this work
+|-- .github/workflows/        # PR validation and CI checks
+`-- README.md
 ```
 
 ## Main Features
@@ -26,8 +26,10 @@ financial-backend-services/
 - View dashboard totals, account cards, recent transactions, limits, and personal stats.
 - Create, edit, delete, and filter accounts.
 - Create `CHECKING`, `SAVINGS`, and `CREDIT` accounts with type-specific validation.
+- See available balance as the primary spendable amount and ledger balance as secondary detail.
 - See frozen accounts with hold warnings and status reasons.
 - Deposit, withdraw, and transfer money.
+- Use available-balance validation for withdrawals and outgoing transfer sources.
 - Keep frozen accounts selectable for credits, while debit-source controls are disabled.
 - Generate an `Idempotency-Key` per money-movement submit.
 - Search and filter transaction history.
@@ -39,6 +41,7 @@ financial-backend-services/
 - Guard admin routes using `ROLE_ADMIN` from JWT claims.
 - Search accounts across users with owner and account type filters.
 - Filter accounts by lifecycle status and freeze or unfreeze accounts with required reasons.
+- Review both available and ledger balances in account oversight.
 - Use existing account create/update/delete flows for admin oversight.
 - Monitor account service health, metrics, deployment information, and manual health checks.
 - Monitor transaction service health, transaction/system stats, alert status, and available metrics.
@@ -59,12 +62,18 @@ financial-backend-services/
   - Account CRUD.
   - Account lifecycle status with `ACTIVE` and `FROZEN` states.
   - Admin-only status updates with reason and updated-by metadata.
+  - Ledger balance, available balance, and account debit hold ownership.
+  - Debit hold placement, capture, and release with idempotent hold IDs.
   - Frozen-account debit rejection while preserving deposits and incoming credits.
+  - Positive balance operations update both ledger and available balances.
   - Account type validation for checking, savings, and credit accounts.
   - Health, metrics, and deployment endpoints.
 - Transaction service:
   - Deposit, withdrawal, and transfer endpoints.
   - Frozen-account debit enforcement before withdrawals and outgoing transfer debits.
+  - Pending debit authorization flow for withdrawals and outgoing transfers.
+  - Debit hold placement and capture before completing debit transactions.
+  - Debit hold release or compensation paths for failed debit orchestration.
   - Transaction history and search.
   - Transaction stats and monitoring endpoints.
   - Idempotency and reversal workflows.
@@ -206,6 +215,54 @@ GET /api/accounts?ownerId=&accountType=&status=&page=&size=
 
 `FROZEN` blocks debits only: withdrawals and outgoing transfer debits are rejected. Deposits and incoming transfer credits remain allowed.
 
+### Internal Account Balance And Holds
+
+`account-service` owns all balance state. Public account JSON keeps `balance` as a compatibility alias for `ledgerBalance`, while newer clients can read both:
+
+```json
+{
+  "balance": 800.00,
+  "ledgerBalance": 800.00,
+  "availableBalance": 800.00
+}
+```
+
+Debit holds reserve spendable funds before a debit completes:
+
+- `PLACED`: decreases `availableBalance` only.
+- `CAPTURED`: decreases `ledgerBalance`; available stays unchanged because funds were already reserved.
+- `RELEASED`: restores `availableBalance`; ledger stays unchanged.
+
+Internal service-to-service endpoints require `ROLE_INTERNAL_SERVICE` or `ROLE_ADMIN`:
+
+```http
+POST /api/internal/accounts/{id}/holds
+POST /api/internal/accounts/{id}/holds/{holdId}/capture
+POST /api/internal/accounts/{id}/holds/{holdId}/release
+```
+
+Place hold body:
+
+```json
+{
+  "holdId": "transaction-id:hold",
+  "transactionId": "transaction-id",
+  "amount": 200.00,
+  "reason": "WITHDRAWAL_HOLD"
+}
+```
+
+Capture and release body:
+
+```json
+{
+  "transactionId": "transaction-id",
+  "reason": "WITHDRAWAL_CAPTURE"
+}
+```
+
+Hold placement is rejected when the account is `FROZEN` or `availableBalance` is too low. Duplicate place/capture/release requests are idempotent when they match the original hold data.
+
 ### Transactions
 
 ```http
@@ -218,6 +275,17 @@ POST /api/transactions/withdraw
 POST /api/transactions/transfer
 POST /api/transactions/{transactionId}/reverse
 ```
+
+Debit transaction behavior:
+
+- Deposits use no hold and increase both ledger and available balances.
+- Withdrawals use `place hold -> capture hold -> complete transaction`.
+- Outgoing transfers use holds on the source account, then credit the destination account.
+- Incoming transfer credits may target a frozen account because credits are allowed.
+- If hold placement or capture fails, the transaction is marked `FAILED` and the failure is audited.
+- If destination credit fails after source capture, transaction-service uses the existing compensation path to credit the source account back.
+
+Processing states include `HOLD_PLACED`, `HOLD_CAPTURED`, and `HOLD_RELEASED`. Audit events include `DEBIT_HOLD_PLACED`, `DEBIT_HOLD_CAPTURED`, `DEBIT_HOLD_RELEASED`, and `DEBIT_HOLD_REJECTED`.
 
 ### Monitoring
 
@@ -365,6 +433,10 @@ The frontend test suite covers:
 - Login/register success and failure states.
 - Account type-specific fields.
 - Account status badges, frozen warnings, admin status filters, and freeze/unfreeze reason validation.
+- Available balance as the primary dashboard/account-card balance.
+- Ledger and available balance display in customer and admin account views.
+- Move Money debit-source disabling based on frozen status and insufficient available balance.
+- Deposit and incoming-credit destination behavior remaining selectable for frozen or held accounts.
 - Transaction table filters.
 - Admin navigation visibility.
 - Admin audit log summary, filters, event table, detail panel, and API proxy mapping.
@@ -389,6 +461,20 @@ cd transaction-service
 The transaction-service test suite also covers the admin audit controller, audit persistence rules, audit filtering, summary counts, and 90-day cleanup. Risk alert tests cover admin-only access, filters, summary counts, status updates with reviewer metadata, rule generation, dedupe behavior, and non-risky transaction handling. Risk case tests cover admin-only access, filters, summary counts, create-from-alert, duplicate open-case handling, claim, status updates, linked alert details, and append-only notes. Investigation tests cover admin-only access, search context expansion, mixed-source timeline sorting, summary counts, CSV export headers/content escaping, and empty search results.
 
 Account hold/freeze tests cover default `ACTIVE` accounts, admin-only freeze/unfreeze with required reasons, frozen debit rejection, credit allowance, transaction-service prechecks, backend rejection messages, frontend status rendering, and move-money debit-source disabling.
+
+Pending debit authorization tests cover account ledger/available initialization, migration backfill, hold placement/capture/release balance effects, idempotent hold transitions, frozen and insufficient-available hold rejection, deposit balance updates, withdrawal and transfer hold orchestration, failed hold audit behavior, compensation after destination credit failure, backward-compatible account DTO handling, and frontend available-balance rendering and validation.
+
+## Live Demo Summary
+
+The pending debit authorization feature was verified against the local end-to-end stack with the real frontend and both backend services:
+
+- Created a customer account with `$1,000.00`.
+- Placed an internal debit hold for `$150.00`.
+- Confirmed the UI showed `Available $850.00` and `Ledger $1,000.00`.
+- Confirmed the withdraw source was disabled for a `$900.00` debit because available balance was only `$850.00`.
+- Released the hold and confirmed available returned to `$1,000.00`.
+- Completed a `$200.00` withdrawal through the UI and confirmed both available and ledger became `$800.00`.
+- Confirmed the transaction history showed a completed withdrawal.
 
 ## Demo Evidence
 
@@ -427,4 +513,3 @@ transaction-service/mvnw
 - Frontend-specific setup: `frontend/README.md`
 - Transaction history API notes: `transaction-service/TRANSACTION-HISTORY-API.md`
 - Monitoring and observability notes: `transaction-service/MONITORING-OBSERVABILITY-GUIDE.md`
-

--- a/account-service/src/main/java/com/suhasan/finance/account_service/controller/InternalAccountController.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/controller/InternalAccountController.java
@@ -2,6 +2,8 @@ package com.suhasan.finance.account_service.controller;
 
 import com.suhasan.finance.account_service.dto.BalanceOperationRequest;
 import com.suhasan.finance.account_service.dto.BalanceOperationResponse;
+import com.suhasan.finance.account_service.dto.DebitHoldRequest;
+import com.suhasan.finance.account_service.dto.DebitHoldResponse;
 import com.suhasan.finance.account_service.service.AccountService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -40,11 +42,43 @@ public class InternalAccountController {
         return ResponseEntity.ok(accountService.applyBalanceOperation(id, request));
     }
 
+    @PostMapping("/{id}/holds")
+    public ResponseEntity<DebitHoldResponse> placeDebitHold(
+            @PathVariable Long id,
+            @Valid @RequestBody DebitHoldRequest request) {
+        return ResponseEntity.ok(accountService.placeDebitHold(id, request));
+    }
+
+    @PostMapping("/{id}/holds/{holdId}/capture")
+    public ResponseEntity<DebitHoldResponse> captureDebitHold(
+            @PathVariable Long id,
+            @PathVariable String holdId,
+            @Valid @RequestBody HoldTransitionRequest request) {
+        return ResponseEntity.ok(accountService.captureDebitHold(id, holdId, request.getTransactionId(), request.getReason()));
+    }
+
+    @PostMapping("/{id}/holds/{holdId}/release")
+    public ResponseEntity<DebitHoldResponse> releaseDebitHold(
+            @PathVariable Long id,
+            @PathVariable String holdId,
+            @Valid @RequestBody HoldTransitionRequest request) {
+        return ResponseEntity.ok(accountService.releaseDebitHold(id, holdId, request.getTransactionId(), request.getReason()));
+    }
+
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
     public static class BalanceUpdateRequest {
         @NotNull(message = "Balance is required")
         private BigDecimal balance;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HoldTransitionRequest {
+        @NotNull(message = "Transaction ID is required")
+        private String transactionId;
+        private String reason;
     }
 }

--- a/account-service/src/main/java/com/suhasan/finance/account_service/dto/AccountResponse.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/dto/AccountResponse.java
@@ -12,6 +12,8 @@ public class AccountResponse {
     private Long id;
     private String ownerId;
     private BigDecimal balance;
+    private BigDecimal ledgerBalance;
+    private BigDecimal availableBalance;
     private LocalDate createdAt;
     private String accountType;
     private AccountStatus status;

--- a/account-service/src/main/java/com/suhasan/finance/account_service/dto/DebitHoldRequest.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/dto/DebitHoldRequest.java
@@ -1,0 +1,34 @@
+package com.suhasan.finance.account_service.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DebitHoldRequest {
+
+    @NotBlank(message = "Hold ID is required")
+    @Size(max = 100, message = "Hold ID must not exceed 100 characters")
+    private String holdId;
+
+    @NotBlank(message = "Transaction ID is required")
+    @Size(max = 100, message = "Transaction ID must not exceed 100 characters")
+    private String transactionId;
+
+    @NotNull(message = "Amount is required")
+    @DecimalMin(value = "0.01", message = "Amount must be greater than zero")
+    private BigDecimal amount;
+
+    @Size(max = 255, message = "Reason must not exceed 255 characters")
+    private String reason;
+}

--- a/account-service/src/main/java/com/suhasan/finance/account_service/dto/DebitHoldResponse.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/dto/DebitHoldResponse.java
@@ -1,0 +1,24 @@
+package com.suhasan.finance.account_service.dto;
+
+import com.suhasan.finance.account_service.entity.DebitHoldStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DebitHoldResponse {
+    private String holdId;
+    private Long accountId;
+    private boolean applied;
+    private BigDecimal ledgerBalance;
+    private BigDecimal availableBalance;
+    private Long version;
+    private DebitHoldStatus status;
+    private String message;
+}

--- a/account-service/src/main/java/com/suhasan/finance/account_service/entity/Account.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/entity/Account.java
@@ -36,7 +36,7 @@ public abstract class Account {
     @Version
     @Column(nullable = false)
     private Long version;
-    
+
 
     @NotNull(message = "Owner ID cannot be null")
     @NotBlank(message = "Owner ID cannot be blank")
@@ -47,6 +47,16 @@ public abstract class Account {
     @PositiveOrZero(message = "Balance must be zero or positive")
     @Column(nullable = false)
     private BigDecimal balance;
+
+    @NotNull(message = "Ledger balance cannot be null")
+    @PositiveOrZero(message = "Ledger balance must be zero or positive")
+    @Column(name = "ledger_balance", nullable = false)
+    private BigDecimal ledgerBalance;
+
+    @NotNull(message = "Available balance cannot be null")
+    @PositiveOrZero(message = "Available balance must be zero or positive")
+    @Column(name = "available_balance", nullable = false)
+    private BigDecimal availableBalance;
 
     @Column(nullable = false, updatable = false)
     private LocalDate createdAt = LocalDate.now();
@@ -68,9 +78,36 @@ public abstract class Account {
     private String accountType;
 
     @PrePersist
-    void ensureDefaultStatus() {
+    void ensureDefaults() {
         if (status == null) {
             status = AccountStatus.ACTIVE;
+        }
+        ensureBalanceAliases();
+    }
+
+    @PreUpdate
+    void ensureBalanceAliases() {
+        if (ledgerBalance == null) {
+            ledgerBalance = balance;
+        }
+        if (balance == null) {
+            balance = ledgerBalance;
+        }
+        if (availableBalance == null) {
+            availableBalance = ledgerBalance;
+        }
+        balance = ledgerBalance;
+    }
+
+    public BigDecimal getBalance() {
+        return ledgerBalance != null ? ledgerBalance : balance;
+    }
+
+    public void setBalance(BigDecimal balance) {
+        this.balance = balance;
+        this.ledgerBalance = balance;
+        if (this.availableBalance == null) {
+            this.availableBalance = balance;
         }
     }
 }

--- a/account-service/src/main/java/com/suhasan/finance/account_service/entity/AccountDebitHold.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/entity/AccountDebitHold.java
@@ -1,0 +1,67 @@
+package com.suhasan.finance.account_service.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "account_debit_holds")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AccountDebitHold {
+
+    @Id
+    @Column(length = 100)
+    private String holdId;
+
+    @Column(nullable = false)
+    private Long accountId;
+
+    @Column(nullable = false, length = 100)
+    private String transactionId;
+
+    @Column(nullable = false, precision = 19, scale = 2)
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private DebitHoldStatus status;
+
+    @Column(length = 255)
+    private String reason;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime capturedAt;
+    private LocalDateTime releasedAt;
+
+    @Column(length = 100)
+    private String capturedByTransactionId;
+
+    @Column(length = 100)
+    private String releasedByTransactionId;
+
+    @Column(length = 255)
+    private String releaseReason;
+
+    @PrePersist
+    void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/account-service/src/main/java/com/suhasan/finance/account_service/entity/DebitHoldStatus.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/entity/DebitHoldStatus.java
@@ -1,0 +1,7 @@
+package com.suhasan.finance.account_service.entity;
+
+public enum DebitHoldStatus {
+    PLACED,
+    CAPTURED,
+    RELEASED
+}

--- a/account-service/src/main/java/com/suhasan/finance/account_service/mapper/AccountMapper.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/mapper/AccountMapper.java
@@ -91,6 +91,10 @@ public interface AccountMapper {
         expression = "java(entity.getAccountType())"
       ),
       @Mapping(
+        target = "balance",
+        expression = "java(entity.getLedgerBalance())"
+      ),
+      @Mapping(
         target = "interestRate",
         expression = "java(entity instanceof SavingsAccount ? ((SavingsAccount)entity).getInterestRate() : null)"
       ),

--- a/account-service/src/main/java/com/suhasan/finance/account_service/repository/AccountDebitHoldRepository.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/repository/AccountDebitHoldRepository.java
@@ -1,0 +1,7 @@
+package com.suhasan.finance.account_service.repository;
+
+import com.suhasan.finance.account_service.entity.AccountDebitHold;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountDebitHoldRepository extends JpaRepository<AccountDebitHold, String> {
+}

--- a/account-service/src/main/java/com/suhasan/finance/account_service/service/AccountService.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/service/AccountService.java
@@ -3,13 +3,18 @@ package com.suhasan.finance.account_service.service;
 import com.suhasan.finance.account_service.dto.AccountResponse;
 import com.suhasan.finance.account_service.dto.BalanceOperationRequest;
 import com.suhasan.finance.account_service.dto.BalanceOperationResponse;
+import com.suhasan.finance.account_service.dto.DebitHoldRequest;
+import com.suhasan.finance.account_service.dto.DebitHoldResponse;
 import com.suhasan.finance.account_service.entity.Account;
 import com.suhasan.finance.account_service.entity.AccountBalanceOperation;
 import com.suhasan.finance.account_service.entity.AccountBalanceOperationId;
+import com.suhasan.finance.account_service.entity.AccountDebitHold;
 import com.suhasan.finance.account_service.entity.AccountStatus;
 import com.suhasan.finance.account_service.entity.BalanceOperationStatus;
+import com.suhasan.finance.account_service.entity.DebitHoldStatus;
 import com.suhasan.finance.account_service.mapper.AccountMapper;
 import com.suhasan.finance.account_service.repository.AccountBalanceOperationRepository;
+import com.suhasan.finance.account_service.repository.AccountDebitHoldRepository;
 import com.suhasan.finance.account_service.repository.AccountRepository;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
@@ -30,6 +35,7 @@ public class AccountService {
 
     private final AccountRepository accountRepository;
     private final AccountBalanceOperationRepository balanceOperationRepository;
+    private final AccountDebitHoldRepository debitHoldRepository;
     private final AccountMapper accountMapper;
     private final MeterRegistry meterRegistry;
 
@@ -38,10 +44,12 @@ public class AccountService {
 
     public AccountService(AccountRepository accountRepository,
                           AccountBalanceOperationRepository balanceOperationRepository,
+                          AccountDebitHoldRepository debitHoldRepository,
                           AccountMapper accountMapper,
                           MeterRegistry meterRegistry) {
         this.accountRepository = accountRepository;
         this.balanceOperationRepository = balanceOperationRepository;
+        this.debitHoldRepository = debitHoldRepository;
         this.accountMapper = accountMapper;
         this.meterRegistry = meterRegistry;
         initMetrics();
@@ -59,6 +67,7 @@ public class AccountService {
         if (account.getStatus() == null) {
             account.setStatus(AccountStatus.ACTIVE);
         }
+        normalizeBalances(account);
         return creationTimer.record(() -> {
             Account saved = accountRepository.save(account);
             createdCounter.increment();
@@ -80,6 +89,8 @@ public class AccountService {
     public Account update(Long id, Account updated) {
         Account existing = findById(id);
         existing.setBalance(updated.getBalance());
+        existing.setLedgerBalance(updated.getBalance());
+        existing.setAvailableBalance(updated.getBalance());
         return accountRepository.save(existing);
     }
 
@@ -125,6 +136,8 @@ public class AccountService {
     public void updateBalance(Long id, BigDecimal newBalance) {
         Account existing = findById(id);
         existing.setBalance(newBalance);
+        existing.setLedgerBalance(newBalance);
+        existing.setAvailableBalance(newBalance);
         accountRepository.save(existing);
     }
 
@@ -133,6 +146,7 @@ public class AccountService {
         AccountBalanceOperation existingOperation = balanceOperationRepository.findById(operationId).orElse(null);
         if (existingOperation != null) {
             Account account = findById(accountId);
+            normalizeBalances(account);
             return BalanceOperationResponse.builder()
                     .accountId(accountId)
                     .operationId(request.getOperationId())
@@ -146,8 +160,10 @@ public class AccountService {
         Account account = accountRepository.findByIdForUpdate(accountId)
                 .orElseThrow(() -> new IllegalArgumentException("Account not found: " + accountId));
 
-        BigDecimal currentBalance = account.getBalance();
+        normalizeBalances(account);
+        BigDecimal currentBalance = account.getLedgerBalance();
         BigDecimal newBalance = currentBalance.add(request.getDelta());
+        BigDecimal newAvailableBalance = account.getAvailableBalance().add(request.getDelta());
         boolean allowNegative = Boolean.TRUE.equals(request.getAllowNegative());
 
         if (account.getStatus() == AccountStatus.FROZEN && request.getDelta().compareTo(BigDecimal.ZERO) < 0) {
@@ -174,7 +190,7 @@ public class AccountService {
                     .build();
         }
 
-        if (!allowNegative && newBalance.compareTo(BigDecimal.ZERO) < 0) {
+        if (!allowNegative && newAvailableBalance.compareTo(BigDecimal.ZERO) < 0) {
             AccountBalanceOperation rejectedOperation = AccountBalanceOperation.builder()
                     .id(operationId)
                     .transactionId(request.getTransactionId())
@@ -197,6 +213,8 @@ public class AccountService {
                     .build();
         }
 
+        account.setLedgerBalance(newBalance);
+        account.setAvailableBalance(newAvailableBalance);
         account.setBalance(newBalance);
         Account savedAccount = accountRepository.save(account);
         AccountBalanceOperation appliedOperation = AccountBalanceOperation.builder()
@@ -219,5 +237,142 @@ public class AccountService {
                 .version(savedAccount.getVersion())
                 .status(BalanceOperationStatus.APPLIED)
                 .build();
+    }
+
+    public DebitHoldResponse placeDebitHold(Long accountId, DebitHoldRequest request) {
+        AccountDebitHold existing = debitHoldRepository.findById(request.getHoldId()).orElse(null);
+        if (existing != null) {
+            validateReplayMatchesRequest(accountId, request, existing);
+            Account account = findById(accountId);
+            normalizeBalances(account);
+            return holdResponse(existing, account, existing.getStatus() == DebitHoldStatus.PLACED);
+        }
+
+        Account account = accountRepository.findByIdForUpdate(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("Account not found: " + accountId));
+        normalizeBalances(account);
+
+        if (account.getStatus() == AccountStatus.FROZEN) {
+            return rejectedHoldResponse(request.getHoldId(), account, "Account is frozen and cannot be debited");
+        }
+        if (account.getAvailableBalance().compareTo(request.getAmount()) < 0) {
+            return rejectedHoldResponse(request.getHoldId(), account, "Insufficient available balance");
+        }
+
+        account.setAvailableBalance(account.getAvailableBalance().subtract(request.getAmount()));
+        Account savedAccount = accountRepository.save(account);
+        AccountDebitHold hold = AccountDebitHold.builder()
+                .holdId(request.getHoldId())
+                .accountId(accountId)
+                .transactionId(request.getTransactionId())
+                .amount(request.getAmount())
+                .reason(request.getReason())
+                .status(DebitHoldStatus.PLACED)
+                .build();
+        debitHoldRepository.save(hold);
+        return holdResponse(hold, savedAccount, true);
+    }
+
+    public DebitHoldResponse captureDebitHold(Long accountId, String holdId, String transactionId, String reason) {
+        Account account = accountRepository.findByIdForUpdate(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("Account not found: " + accountId));
+        normalizeBalances(account);
+        AccountDebitHold hold = debitHoldRepository.findById(holdId)
+                .orElseThrow(() -> new IllegalArgumentException("Debit hold not found: " + holdId));
+        validateHoldAccount(accountId, hold);
+        if (hold.getStatus() == DebitHoldStatus.CAPTURED) {
+            return holdResponse(hold, account, true);
+        }
+        if (hold.getStatus() != DebitHoldStatus.PLACED) {
+            return holdResponse(hold, account, false, "Debit hold is not active");
+        }
+
+        account.setLedgerBalance(account.getLedgerBalance().subtract(hold.getAmount()));
+        account.setBalance(account.getLedgerBalance());
+        Account savedAccount = accountRepository.save(account);
+        hold.setStatus(DebitHoldStatus.CAPTURED);
+        hold.setCapturedAt(LocalDateTime.now());
+        hold.setCapturedByTransactionId(transactionId);
+        hold.setReason(reason != null ? reason : hold.getReason());
+        debitHoldRepository.save(hold);
+        return holdResponse(hold, savedAccount, true);
+    }
+
+    public DebitHoldResponse releaseDebitHold(Long accountId, String holdId, String transactionId, String reason) {
+        Account account = accountRepository.findByIdForUpdate(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("Account not found: " + accountId));
+        normalizeBalances(account);
+        AccountDebitHold hold = debitHoldRepository.findById(holdId)
+                .orElseThrow(() -> new IllegalArgumentException("Debit hold not found: " + holdId));
+        validateHoldAccount(accountId, hold);
+        if (hold.getStatus() == DebitHoldStatus.RELEASED) {
+            return holdResponse(hold, account, true);
+        }
+        if (hold.getStatus() != DebitHoldStatus.PLACED) {
+            return holdResponse(hold, account, false, "Debit hold is not active");
+        }
+
+        account.setAvailableBalance(account.getAvailableBalance().add(hold.getAmount()));
+        Account savedAccount = accountRepository.save(account);
+        hold.setStatus(DebitHoldStatus.RELEASED);
+        hold.setReleasedAt(LocalDateTime.now());
+        hold.setReleasedByTransactionId(transactionId);
+        hold.setReleaseReason(reason);
+        debitHoldRepository.save(hold);
+        return holdResponse(hold, savedAccount, true);
+    }
+
+    private void validateHoldAccount(Long accountId, AccountDebitHold hold) {
+        if (!accountId.equals(hold.getAccountId())) {
+            throw new IllegalArgumentException("Debit hold does not belong to account: " + accountId);
+        }
+    }
+
+    private DebitHoldResponse rejectedHoldResponse(String holdId, Account account, String message) {
+        return DebitHoldResponse.builder()
+                .holdId(holdId)
+                .accountId(account.getId())
+                .applied(false)
+                .ledgerBalance(account.getLedgerBalance())
+                .availableBalance(account.getAvailableBalance())
+                .version(account.getVersion())
+                .status(null)
+                .message(message)
+                .build();
+    }
+
+    private DebitHoldResponse holdResponse(AccountDebitHold hold, Account account, boolean applied) {
+        return holdResponse(hold, account, applied, null);
+    }
+
+    private DebitHoldResponse holdResponse(AccountDebitHold hold, Account account, boolean applied, String message) {
+        return DebitHoldResponse.builder()
+                .holdId(hold.getHoldId())
+                .accountId(account.getId())
+                .applied(applied)
+                .ledgerBalance(account.getLedgerBalance())
+                .availableBalance(account.getAvailableBalance())
+                .version(account.getVersion())
+                .status(hold.getStatus())
+                .message(message)
+                .build();
+    }
+
+    private void normalizeBalances(Account account) {
+        if (account.getLedgerBalance() == null) {
+            account.setLedgerBalance(account.getBalance());
+        }
+        if (account.getAvailableBalance() == null) {
+            account.setAvailableBalance(account.getLedgerBalance());
+        }
+        account.setBalance(account.getLedgerBalance());
+    }
+
+    private void validateReplayMatchesRequest(Long accountId, DebitHoldRequest request, AccountDebitHold existing) {
+        if (!accountId.equals(existing.getAccountId())
+                || !request.getTransactionId().equals(existing.getTransactionId())
+                || request.getAmount().compareTo(existing.getAmount()) != 0) {
+            throw new IllegalArgumentException("Debit hold replay does not match original request: " + request.getHoldId());
+        }
     }
 }

--- a/account-service/src/main/resources/db/migration/V4__add_available_balance_and_debit_holds.sql
+++ b/account-service/src/main/resources/db/migration/V4__add_available_balance_and_debit_holds.sql
@@ -1,0 +1,42 @@
+ALTER TABLE accounts
+    ADD COLUMN ledger_balance NUMERIC(38,2);
+
+ALTER TABLE accounts
+    ADD COLUMN available_balance NUMERIC(38,2);
+
+UPDATE accounts
+SET ledger_balance = balance
+WHERE ledger_balance IS NULL;
+
+UPDATE accounts
+SET available_balance = balance
+WHERE available_balance IS NULL;
+
+ALTER TABLE accounts
+    ALTER COLUMN ledger_balance SET NOT NULL;
+
+ALTER TABLE accounts
+    ALTER COLUMN available_balance SET NOT NULL;
+
+CREATE TABLE IF NOT EXISTS account_debit_holds (
+    hold_id VARCHAR(100) PRIMARY KEY,
+    account_id BIGINT NOT NULL,
+    transaction_id VARCHAR(100) NOT NULL,
+    amount NUMERIC(19,2) NOT NULL,
+    status VARCHAR(32) NOT NULL,
+    reason VARCHAR(255),
+    created_at TIMESTAMP NOT NULL,
+    captured_at TIMESTAMP,
+    released_at TIMESTAMP,
+    captured_by_transaction_id VARCHAR(100),
+    released_by_transaction_id VARCHAR(100),
+    release_reason VARCHAR(255),
+    CONSTRAINT chk_account_debit_holds_status
+        CHECK (status IN ('PLACED', 'CAPTURED', 'RELEASED'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_debit_holds_account_id
+    ON account_debit_holds (account_id);
+
+CREATE INDEX IF NOT EXISTS idx_account_debit_holds_transaction_id
+    ON account_debit_holds (transaction_id);

--- a/account-service/src/test/java/com/suhasan/finance/account_service/migration/AvailableBalanceMigrationTest.java
+++ b/account-service/src/test/java/com/suhasan/finance/account_service/migration/AvailableBalanceMigrationTest.java
@@ -1,0 +1,44 @@
+package com.suhasan.finance.account_service.migration;
+
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AvailableBalanceMigrationTest {
+
+    @Test
+    void v4BackfillsLedgerAndAvailableBalancesFromExistingBalance() {
+        JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL("jdbc:h2:mem:available-balance-migration-" + System.nanoTime() + ";MODE=PostgreSQL;DB_CLOSE_DELAY=-1");
+        dataSource.setUser("sa");
+        dataSource.setPassword("");
+
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+        jdbc.execute("CREATE TABLE accounts (id BIGINT PRIMARY KEY, balance NUMERIC(38,2) NOT NULL)");
+        jdbc.update("INSERT INTO accounts (id, balance) VALUES (?, ?)", 1L, new BigDecimal("123.45"));
+
+        ResourceDatabasePopulator populator = new ResourceDatabasePopulator(
+                new FileSystemResource("src/main/resources/db/migration/V4__add_available_balance_and_debit_holds.sql"));
+        populator.execute(dataSource);
+
+        BigDecimal ledgerBalance = jdbc.queryForObject(
+                "SELECT ledger_balance FROM accounts WHERE id = 1",
+                BigDecimal.class);
+        BigDecimal availableBalance = jdbc.queryForObject(
+                "SELECT available_balance FROM accounts WHERE id = 1",
+                BigDecimal.class);
+        Integer holdTableCount = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'ACCOUNT_DEBIT_HOLDS'",
+                Integer.class);
+
+        assertThat(ledgerBalance).isEqualByComparingTo("123.45");
+        assertThat(availableBalance).isEqualByComparingTo("123.45");
+        assertThat(holdTableCount).isEqualTo(1);
+    }
+}

--- a/account-service/src/test/java/com/suhasan/finance/account_service/service/AccountServiceTest.java
+++ b/account-service/src/test/java/com/suhasan/finance/account_service/service/AccountServiceTest.java
@@ -5,8 +5,12 @@ import com.suhasan.finance.account_service.entity.CheckingAccount;
 import com.suhasan.finance.account_service.entity.AccountStatus;
 import com.suhasan.finance.account_service.dto.BalanceOperationRequest;
 import com.suhasan.finance.account_service.dto.BalanceOperationResponse;
+import com.suhasan.finance.account_service.dto.DebitHoldRequest;
+import com.suhasan.finance.account_service.dto.DebitHoldResponse;
+import com.suhasan.finance.account_service.entity.DebitHoldStatus;
 import com.suhasan.finance.account_service.mapper.AccountMapper;
 import com.suhasan.finance.account_service.repository.AccountBalanceOperationRepository;
+import com.suhasan.finance.account_service.repository.AccountDebitHoldRepository;
 import com.suhasan.finance.account_service.repository.AccountRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +43,9 @@ public class AccountServiceTest {
     private AccountBalanceOperationRepository balanceOperationRepository;
 
     @Mock
+    private AccountDebitHoldRepository debitHoldRepository;
+
+    @Mock
     private MeterRegistry meterRegistry;
 
     private AccountService accountService;
@@ -49,15 +56,15 @@ public class AccountServiceTest {
         // Mock the meter registry components with lenient stubbing
         io.micrometer.core.instrument.Counter counter = mock(io.micrometer.core.instrument.Counter.class);
         io.micrometer.core.instrument.Timer timer = mock(io.micrometer.core.instrument.Timer.class);
-        
+
         lenient().when(meterRegistry.counter(anyString())).thenReturn(counter);
         lenient().when(meterRegistry.timer(anyString())).thenReturn(timer);
         lenient().when(timer.record(org.mockito.ArgumentMatchers.<java.util.function.Supplier<Account>>any())).thenAnswer(invocation -> {
             java.util.function.Supplier<Account> supplier = invocation.getArgument(0);
             return supplier.get();
         });
-        
-        accountService = new AccountService(accountRepository, balanceOperationRepository, accountMapper, meterRegistry);
+
+        accountService = new AccountService(accountRepository, balanceOperationRepository, debitHoldRepository, accountMapper, meterRegistry);
 
         testAccount = new CheckingAccount();
         testAccount.setId(1L);
@@ -88,6 +95,8 @@ public class AccountServiceTest {
         Account result = accountService.create(testAccount);
 
         assertThat(result.getStatus()).isEqualTo(AccountStatus.ACTIVE);
+        assertThat(result.getLedgerBalance()).isEqualByComparingTo("1000.00");
+        assertThat(result.getAvailableBalance()).isEqualByComparingTo("1000.00");
     }
 
     @Test
@@ -154,6 +163,206 @@ public class AccountServiceTest {
 
         assertThat(response.isApplied()).isTrue();
         assertThat(response.getNewBalance()).isEqualByComparingTo("1025.00");
+        assertThat(testAccount.getLedgerBalance()).isEqualByComparingTo("1025.00");
+        assertThat(testAccount.getAvailableBalance()).isEqualByComparingTo("1025.00");
+    }
+
+    @Test
+    @DisplayName("Should place debit hold against available balance only")
+    void shouldPlaceDebitHoldAgainstAvailableBalanceOnly() {
+        when(accountRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(testAccount));
+        when(debitHoldRepository.findById("hold-1")).thenReturn(Optional.empty());
+        when(accountRepository.save(any(Account.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        DebitHoldResponse response = accountService.placeDebitHold(1L, DebitHoldRequest.builder()
+                .holdId("hold-1")
+                .transactionId("tx-1")
+                .amount(BigDecimal.valueOf(250))
+                .reason("WITHDRAWAL")
+                .build());
+
+        assertThat(response.isApplied()).isTrue();
+        assertThat(response.getStatus()).isEqualTo(DebitHoldStatus.PLACED);
+        assertThat(response.getLedgerBalance()).isEqualByComparingTo("1000.00");
+        assertThat(response.getAvailableBalance()).isEqualByComparingTo("750.00");
+    }
+
+    @Test
+    @DisplayName("Should capture debit hold against ledger balance only")
+    void shouldCaptureDebitHoldAgainstLedgerBalanceOnly() {
+        testAccount.setAvailableBalance(BigDecimal.valueOf(750));
+        com.suhasan.finance.account_service.entity.AccountDebitHold hold = com.suhasan.finance.account_service.entity.AccountDebitHold.builder()
+                .holdId("hold-1")
+                .accountId(1L)
+                .transactionId("tx-1")
+                .amount(BigDecimal.valueOf(250))
+                .status(DebitHoldStatus.PLACED)
+                .build();
+        when(accountRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(testAccount));
+        when(debitHoldRepository.findById("hold-1")).thenReturn(Optional.of(hold));
+        when(accountRepository.save(any(Account.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        DebitHoldResponse response = accountService.captureDebitHold(1L, "hold-1", "tx-1", "WITHDRAWAL_CAPTURE");
+
+        assertThat(response.isApplied()).isTrue();
+        assertThat(response.getStatus()).isEqualTo(DebitHoldStatus.CAPTURED);
+        assertThat(response.getLedgerBalance()).isEqualByComparingTo("750.00");
+        assertThat(response.getAvailableBalance()).isEqualByComparingTo("750.00");
+    }
+
+    @Test
+    @DisplayName("Should release debit hold back to available balance")
+    void shouldReleaseDebitHoldBackToAvailableBalance() {
+        testAccount.setAvailableBalance(BigDecimal.valueOf(750));
+        com.suhasan.finance.account_service.entity.AccountDebitHold hold = com.suhasan.finance.account_service.entity.AccountDebitHold.builder()
+                .holdId("hold-1")
+                .accountId(1L)
+                .transactionId("tx-1")
+                .amount(BigDecimal.valueOf(250))
+                .status(DebitHoldStatus.PLACED)
+                .build();
+        when(accountRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(testAccount));
+        when(debitHoldRepository.findById("hold-1")).thenReturn(Optional.of(hold));
+        when(accountRepository.save(any(Account.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        DebitHoldResponse response = accountService.releaseDebitHold(1L, "hold-1", "tx-1", "WITHDRAWAL_RELEASE");
+
+        assertThat(response.isApplied()).isTrue();
+        assertThat(response.getStatus()).isEqualTo(DebitHoldStatus.RELEASED);
+        assertThat(response.getLedgerBalance()).isEqualByComparingTo("1000.00");
+        assertThat(response.getAvailableBalance()).isEqualByComparingTo("1000.00");
+    }
+
+    @Test
+    @DisplayName("Should reject debit hold when available balance is insufficient")
+    void shouldRejectDebitHoldWhenAvailableBalanceIsInsufficient() {
+        testAccount.setAvailableBalance(BigDecimal.valueOf(50));
+        when(accountRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(testAccount));
+        when(debitHoldRepository.findById("hold-1")).thenReturn(Optional.empty());
+
+        DebitHoldResponse response = accountService.placeDebitHold(1L, DebitHoldRequest.builder()
+                .holdId("hold-1")
+                .transactionId("tx-1")
+                .amount(BigDecimal.valueOf(250))
+                .reason("WITHDRAWAL")
+                .build());
+
+        assertThat(response.isApplied()).isFalse();
+        assertThat(response.getStatus()).isNull();
+        assertThat(response.getMessage()).isEqualTo("Insufficient available balance");
+    }
+
+    @Test
+    @DisplayName("Should reject debit hold for frozen account")
+    void shouldRejectDebitHoldForFrozenAccount() {
+        testAccount.setStatus(AccountStatus.FROZEN);
+        when(accountRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(testAccount));
+        when(debitHoldRepository.findById("hold-1")).thenReturn(Optional.empty());
+
+        DebitHoldResponse response = accountService.placeDebitHold(1L, DebitHoldRequest.builder()
+                .holdId("hold-1")
+                .transactionId("tx-1")
+                .amount(BigDecimal.valueOf(250))
+                .reason("WITHDRAWAL")
+                .build());
+
+        assertThat(response.isApplied()).isFalse();
+        assertThat(response.getStatus()).isNull();
+        assertThat(response.getMessage()).isEqualTo("Account is frozen and cannot be debited");
+    }
+
+    @Test
+    @DisplayName("Should return existing hold for matching place replay")
+    void shouldReturnExistingHoldForMatchingPlaceReplay() {
+        testAccount.setAvailableBalance(BigDecimal.valueOf(750));
+        com.suhasan.finance.account_service.entity.AccountDebitHold hold = com.suhasan.finance.account_service.entity.AccountDebitHold.builder()
+                .holdId("hold-1")
+                .accountId(1L)
+                .transactionId("tx-1")
+                .amount(BigDecimal.valueOf(250))
+                .status(DebitHoldStatus.PLACED)
+                .build();
+        when(debitHoldRepository.findById("hold-1")).thenReturn(Optional.of(hold));
+        when(accountRepository.findById(1L)).thenReturn(Optional.of(testAccount));
+
+        DebitHoldResponse response = accountService.placeDebitHold(1L, DebitHoldRequest.builder()
+                .holdId("hold-1")
+                .transactionId("tx-1")
+                .amount(BigDecimal.valueOf(250))
+                .reason("WITHDRAWAL")
+                .build());
+
+        assertThat(response.isApplied()).isTrue();
+        assertThat(response.getStatus()).isEqualTo(DebitHoldStatus.PLACED);
+        assertThat(response.getAvailableBalance()).isEqualByComparingTo("750.00");
+        verify(accountRepository, never()).save(any(Account.class));
+    }
+
+    @Test
+    @DisplayName("Should reject mismatched place replay")
+    void shouldRejectMismatchedPlaceReplay() {
+        com.suhasan.finance.account_service.entity.AccountDebitHold hold = com.suhasan.finance.account_service.entity.AccountDebitHold.builder()
+                .holdId("hold-1")
+                .accountId(1L)
+                .transactionId("tx-1")
+                .amount(BigDecimal.valueOf(250))
+                .status(DebitHoldStatus.PLACED)
+                .build();
+        when(debitHoldRepository.findById("hold-1")).thenReturn(Optional.of(hold));
+
+        assertThatThrownBy(() -> accountService.placeDebitHold(2L, DebitHoldRequest.builder()
+                .holdId("hold-1")
+                .transactionId("tx-1")
+                .amount(BigDecimal.valueOf(250))
+                .reason("WITHDRAWAL")
+                .build()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Debit hold replay does not match original request");
+    }
+
+    @Test
+    @DisplayName("Should return captured hold for duplicate capture")
+    void shouldReturnCapturedHoldForDuplicateCapture() {
+        testAccount.setLedgerBalance(BigDecimal.valueOf(750));
+        testAccount.setAvailableBalance(BigDecimal.valueOf(750));
+        com.suhasan.finance.account_service.entity.AccountDebitHold hold = com.suhasan.finance.account_service.entity.AccountDebitHold.builder()
+                .holdId("hold-1")
+                .accountId(1L)
+                .transactionId("tx-1")
+                .amount(BigDecimal.valueOf(250))
+                .status(DebitHoldStatus.CAPTURED)
+                .build();
+        when(accountRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(testAccount));
+        when(debitHoldRepository.findById("hold-1")).thenReturn(Optional.of(hold));
+
+        DebitHoldResponse response = accountService.captureDebitHold(1L, "hold-1", "tx-1", "WITHDRAWAL_CAPTURE");
+
+        assertThat(response.isApplied()).isTrue();
+        assertThat(response.getStatus()).isEqualTo(DebitHoldStatus.CAPTURED);
+        assertThat(response.getLedgerBalance()).isEqualByComparingTo("750.00");
+        verify(accountRepository, never()).save(any(Account.class));
+    }
+
+    @Test
+    @DisplayName("Should return released hold for duplicate release")
+    void shouldReturnReleasedHoldForDuplicateRelease() {
+        testAccount.setAvailableBalance(BigDecimal.valueOf(1000));
+        com.suhasan.finance.account_service.entity.AccountDebitHold hold = com.suhasan.finance.account_service.entity.AccountDebitHold.builder()
+                .holdId("hold-1")
+                .accountId(1L)
+                .transactionId("tx-1")
+                .amount(BigDecimal.valueOf(250))
+                .status(DebitHoldStatus.RELEASED)
+                .build();
+        when(accountRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(testAccount));
+        when(debitHoldRepository.findById("hold-1")).thenReturn(Optional.of(hold));
+
+        DebitHoldResponse response = accountService.releaseDebitHold(1L, "hold-1", "tx-1", "WITHDRAWAL_RELEASE");
+
+        assertThat(response.isApplied()).isTrue();
+        assertThat(response.getStatus()).isEqualTo(DebitHoldStatus.RELEASED);
+        assertThat(response.getAvailableBalance()).isEqualByComparingTo("1000.00");
+        verify(accountRepository, never()).save(any(Account.class));
     }
 
     @Test

--- a/frontend/src/lib/accountBalances.ts
+++ b/frontend/src/lib/accountBalances.ts
@@ -1,0 +1,13 @@
+import type { Account } from "../types";
+
+export function ledgerBalance(account: Account) {
+  return Number(account.ledgerBalance ?? account.balance);
+}
+
+export function availableBalance(account: Account) {
+  return Number(account.availableBalance ?? account.balance);
+}
+
+export function canDebit(account: Account, amount = 0) {
+  return account.status !== "FROZEN" && availableBalance(account) >= amount;
+}

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import { createAccount, deleteAccount, listAccounts, updateAccount } from "../lib/queries";
 import { accountSchema, type AccountValues } from "../lib/schemas";
 import { compactDate, money } from "../lib/format";
+import { availableBalance, ledgerBalance } from "../lib/accountBalances";
 import type { Account } from "../types";
 import { Button, EmptyState, ErrorNotice, Field, Input, Panel, Select } from "../components/ui";
 import { StatusBadge } from "../components/StatusBadge";
@@ -128,8 +129,12 @@ export function AccountsPage() {
               </div>
             ) : null}
             <div className="flex justify-between gap-3">
-              <dt className="text-muted">Balance</dt>
-              <dd>{money(selected.balance)}</dd>
+              <dt className="text-muted">Available</dt>
+              <dd>{money(availableBalance(selected))}</dd>
+            </div>
+            <div className="flex justify-between gap-3">
+              <dt className="text-muted">Ledger</dt>
+              <dd>{money(ledgerBalance(selected))}</dd>
             </div>
             <div className="flex justify-between gap-3">
               <dt className="text-muted">Opened</dt>
@@ -161,7 +166,8 @@ export function AccountsPage() {
                   <th>Owner</th>
                   <th>Type</th>
                   <th>Status</th>
-                  <th>Balance</th>
+                  <th>Available</th>
+                  <th>Ledger</th>
                   <th>Opened</th>
                   <th className="text-right">Action</th>
                 </tr>
@@ -177,7 +183,8 @@ export function AccountsPage() {
                     <td>
                       <StatusBadge value={account.status ?? "ACTIVE"} />
                     </td>
-                    <td>{money(account.balance)}</td>
+                    <td>{money(availableBalance(account))}</td>
+                    <td>{money(ledgerBalance(account))}</td>
                     <td>{compactDate(account.createdAt)}</td>
                     <td className="text-right">
                       <div className="flex justify-end gap-2">

--- a/frontend/src/pages/AdminAccountsPage.tsx
+++ b/frontend/src/pages/AdminAccountsPage.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 import { createAccount, deleteAccount, listAccounts, updateAccount, updateAccountStatus } from "../lib/queries";
 import { accountSchema, type AccountValues } from "../lib/schemas";
 import { compactDate, money } from "../lib/format";
+import { availableBalance, ledgerBalance } from "../lib/accountBalances";
 import type { Account } from "../types";
 import { Button, ErrorNotice, Field, Input, Panel, Select } from "../components/ui";
 import { StatusBadge } from "../components/StatusBadge";
@@ -179,7 +180,8 @@ export function AdminAccountsPage() {
                 <th>Owner</th>
                 <th>Type</th>
                 <th>Status</th>
-                <th>Balance</th>
+                <th>Available</th>
+                <th>Ledger</th>
                 <th>Opened</th>
                 <th className="text-right">Actions</th>
               </tr>
@@ -195,7 +197,8 @@ export function AdminAccountsPage() {
                   <td>
                     <StatusBadge value={account.status ?? "ACTIVE"} />
                   </td>
-                  <td>{money(account.balance)}</td>
+                  <td>{money(availableBalance(account))}</td>
+                  <td>{money(ledgerBalance(account))}</td>
                   <td>{compactDate(account.createdAt)}</td>
                   <td className="text-right">
                     <div className="flex justify-end gap-2">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { listAccounts, getLimits, getTransactions, getUserStats } from "../lib/queries";
 import { compactDate, money, percent } from "../lib/format";
+import { availableBalance, ledgerBalance } from "../lib/accountBalances";
 import { EmptyState, Panel, Stat } from "../components/ui";
 import { StatusBadge } from "../components/StatusBadge";
 
@@ -12,7 +13,7 @@ export function DashboardPage() {
   const transactions = useQuery({ queryKey: ["transactions", 0], queryFn: () => getTransactions(0) });
   const stats = useQuery({ queryKey: ["stats", "user"], queryFn: getUserStats });
   const limits = useQuery({ queryKey: ["limits"], queryFn: getLimits });
-  const totalBalance = accounts.data?.content.reduce((sum, account) => sum + Number(account.balance), 0) ?? 0;
+  const totalBalance = accounts.data?.content.reduce((sum, account) => sum + availableBalance(account), 0) ?? 0;
   const chartData = Object.entries(stats.data?.transactionAmountsByType ?? {}).map(([name, value]) => ({ name, value }));
 
   return (
@@ -34,7 +35,7 @@ export function DashboardPage() {
         </div>
       </div>
       <div className="grid gap-3 md:grid-cols-4">
-        <Stat label="Total balance" value={money(totalBalance)} />
+        <Stat label="Available balance" value={money(totalBalance)} />
         <Stat label="Transactions" value={stats.data?.totalTransactions ?? 0} />
         <Stat label="Success rate" value={percent(stats.data?.successRate)} />
         <Stat label="Single limit" value={money(limits.data?.singleTransactionLimit, limits.data?.currency)} />
@@ -52,7 +53,8 @@ export function DashboardPage() {
                       <StatusBadge value={account.status ?? "ACTIVE"} />
                     </div>
                   </div>
-                  <p className="mt-2 text-2xl font-semibold">{money(account.balance)}</p>
+                  <p className="mt-2 text-2xl font-semibold">{money(availableBalance(account))}</p>
+                  <p className="text-xs text-muted">Ledger {money(ledgerBalance(account))}</p>
                   {account.status === "FROZEN" ? <p className="text-xs text-danger">{account.statusReason || "Debit hold active"}</p> : null}
                   <p className="text-xs text-muted">Opened {compactDate(account.createdAt)}</p>
                 </div>

--- a/frontend/src/pages/MoveMoneyPage.tsx
+++ b/frontend/src/pages/MoveMoneyPage.tsx
@@ -4,17 +4,18 @@ import type { UseFormRegisterReturn } from "react-hook-form";
 import { useForm } from "react-hook-form";
 import { deposit, listAccounts, transfer, withdraw } from "../lib/queries";
 import { createIdempotencyKey } from "../lib/idempotency";
+import { availableBalance, canDebit } from "../lib/accountBalances";
 import { moneyMovementSchema, transferSchema, type MoneyMovementValues, type TransferValues } from "../lib/schemas";
 import { Button, ErrorNotice, Field, Input, Panel, Select } from "../components/ui";
 
-function AccountSelect({ field, debitSource = false }: { field: UseFormRegisterReturn; debitSource?: boolean }) {
+function AccountSelect({ field, debitSource = false, amount = 0 }: { field: UseFormRegisterReturn; debitSource?: boolean; amount?: number }) {
   const accounts = useQuery({ queryKey: ["accounts"], queryFn: () => listAccounts() });
   return (
     <Select {...field}>
       <option value="">Select account</option>
       {accounts.data?.content.map((account) => (
-        <option key={account.id} value={String(account.id)} disabled={debitSource && account.status === "FROZEN"}>
-          #{account.id} - {account.accountType}{account.status === "FROZEN" ? " - FROZEN" : ""}
+        <option key={account.id} value={String(account.id)} disabled={debitSource && !canDebit(account, amount)}>
+          #{account.id} - {account.accountType} - Available {availableBalance(account).toFixed(2)}{account.status === "FROZEN" ? " - FROZEN" : ""}
         </option>
       ))}
     </Select>
@@ -26,6 +27,8 @@ export function MoveMoneyPage() {
   const depositForm = useForm<MoneyMovementValues>({ resolver: zodResolver(moneyMovementSchema), defaultValues: { accountId: "", amount: 0, currency: "USD", description: "", reference: "" } });
   const withdrawForm = useForm<MoneyMovementValues>({ resolver: zodResolver(moneyMovementSchema), defaultValues: { accountId: "", amount: 0, currency: "USD", description: "", reference: "" } });
   const transferForm = useForm<TransferValues>({ resolver: zodResolver(transferSchema), defaultValues: { fromAccountId: "", toAccountId: "", amount: 0, currency: "USD", description: "", reference: "" } });
+  const withdrawAmount = Number(withdrawForm.watch("amount") || 0);
+  const transferAmount = Number(transferForm.watch("amount") || 0);
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: ["accounts"] });
     queryClient.invalidateQueries({ queryKey: ["transactions"] });
@@ -51,7 +54,7 @@ export function MoveMoneyPage() {
         <form className="grid gap-4" onSubmit={withdrawForm.handleSubmit((values) => withdrawMutation.mutate(values))}>
           <ErrorNotice message={withdrawMutation.error instanceof Error ? withdrawMutation.error.message : undefined} />
           <Field label="Withdraw account" error={withdrawForm.formState.errors.accountId?.message}>
-            <AccountSelect field={withdrawForm.register("accountId")} debitSource />
+            <AccountSelect field={withdrawForm.register("accountId")} debitSource amount={withdrawAmount} />
           </Field>
           <MoneyFields form={withdrawForm} />
           <Button type="submit" disabled={withdrawMutation.isPending}>Withdraw</Button>
@@ -61,7 +64,7 @@ export function MoveMoneyPage() {
         <form className="grid gap-4" onSubmit={transferForm.handleSubmit((values) => transferMutation.mutate(values))}>
           <ErrorNotice message={transferMutation.error instanceof Error ? transferMutation.error.message : undefined} />
           <Field label="From account" error={transferForm.formState.errors.fromAccountId?.message}>
-            <AccountSelect field={transferForm.register("fromAccountId")} debitSource />
+            <AccountSelect field={transferForm.register("fromAccountId")} debitSource amount={transferAmount} />
           </Field>
           <Field label="To account" error={transferForm.formState.errors.toAccountId?.message}>
             <AccountSelect field={transferForm.register("toAccountId")} />

--- a/frontend/src/test/app.component.test.tsx
+++ b/frontend/src/test/app.component.test.tsx
@@ -12,6 +12,8 @@ const sampleAccount = {
   ownerId: "customer",
   accountType: "CHECKING",
   balance: 250,
+  ledgerBalance: 250,
+  availableBalance: 175,
   createdAt: "2026-04-28T10:00:00Z",
   status: "ACTIVE"
 };
@@ -19,6 +21,8 @@ const sampleAccount = {
 const frozenAccount = {
   ...sampleAccount,
   id: 202,
+  ledgerBalance: 250,
+  availableBalance: 250,
   status: "FROZEN",
   statusReason: "Fraud review"
 };
@@ -194,6 +198,16 @@ describe("auth screens", () => {
 });
 
 describe("account forms", () => {
+  it("shows available balance as primary and ledger balance as secondary on dashboard", async () => {
+    mockFetch();
+
+    renderApp("/", tokenFor({ sub: "customer", roles: ["ROLE_USER"] }));
+
+    expect(await screen.findByText("Available balance")).toBeInTheDocument();
+    expect((await screen.findAllByText("$175.00")).length).toBeGreaterThan(0);
+    expect(await screen.findByText("Ledger $250.00")).toBeInTheDocument();
+  });
+
   it("renders account type-specific fields", async () => {
     const user = userEvent.setup();
     mockFetch();
@@ -333,6 +347,17 @@ describe("admin audit log", () => {
 });
 
 describe("admin account status controls", () => {
+  it("shows available and ledger balance columns", async () => {
+    mockFetch();
+
+    renderApp("/admin/accounts", tokenFor({ sub: "admin", roles: ["ROLE_ADMIN"] }));
+
+    expect(await screen.findByRole("columnheader", { name: "Available" })).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Ledger" })).toBeInTheDocument();
+    expect(await screen.findByText("$175.00")).toBeInTheDocument();
+    expect(await screen.findByText("$250.00")).toBeInTheDocument();
+  });
+
   it("freezes account with a required reason", async () => {
     const user = userEvent.setup();
     const { calls } = mockFetch((url, init) => {
@@ -372,14 +397,34 @@ describe("money movement account holds", () => {
 
     renderApp("/move-money", tokenFor({ sub: "customer", roles: ["ROLE_USER"] }));
 
-    await screen.findAllByText(/#202 - CHECKING - FROZEN/);
+    await screen.findAllByText(/#202 - CHECKING - Available 250.00 - FROZEN/);
     const depositSelect = screen.getAllByLabelText("Account")[0];
     const withdrawSelect = screen.getByLabelText("Withdraw account");
     const frozenDebitOption = Array.from(withdrawSelect.querySelectorAll("option")).find((option) => option.value === "202");
 
-    expect(depositSelect).toHaveTextContent("#202 - CHECKING - FROZEN");
-    expect(withdrawSelect).toHaveTextContent("#202 - CHECKING - FROZEN");
+    expect(depositSelect).toHaveTextContent("#202 - CHECKING - Available 250.00 - FROZEN");
+    expect(withdrawSelect).toHaveTextContent("#202 - CHECKING - Available 250.00 - FROZEN");
     expect(frozenDebitOption).toBeDisabled();
+  });
+
+  it("disables debit source accounts when requested amount exceeds available balance", async () => {
+    const user = userEvent.setup();
+    mockFetch((url) => {
+      if (url.includes("/api/accounts")) {
+        return jsonResponse({ ...emptyPage, content: [sampleAccount], totalElements: 1, totalPages: 1 });
+      }
+      return undefined;
+    });
+
+    renderApp("/move-money", tokenFor({ sub: "customer", roles: ["ROLE_USER"] }));
+
+    await user.clear(screen.getAllByLabelText("Amount")[1]);
+    await user.type(screen.getAllByLabelText("Amount")[1], "200");
+    const withdrawSelect = screen.getByLabelText("Withdraw account");
+    const activeDebitOption = Array.from(withdrawSelect.querySelectorAll("option")).find((option) => option.value === "101");
+
+    expect(activeDebitOption).toBeDisabled();
+    expect(withdrawSelect).toHaveTextContent("#101 - CHECKING - Available 175.00");
   });
 });
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -17,6 +17,8 @@ export type Account = {
   id: number;
   ownerId: string;
   balance: number;
+  ledgerBalance?: number;
+  availableBalance?: number;
   createdAt: string;
   accountType: AccountType;
   status?: AccountStatus;

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/client/ResilientAccountServiceClient.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/client/ResilientAccountServiceClient.java
@@ -173,6 +173,94 @@ public class ResilientAccountServiceClient {
                 .transformDeferred(TimeLimiterOperator.of(accountServiceTimeLimiter));
     }
 
+    @CacheEvict(value = "account:validation", key = "#accountId")
+    public DebitHoldResponse placeDebitHold(String accountId,
+                                            String holdId,
+                                            BigDecimal amount,
+                                            String transactionId,
+                                            String reason) {
+        try {
+            return placeDebitHoldAsync(accountId, holdId, amount, transactionId, reason).block();
+        } catch (Exception e) {
+            throw mapServiceException("debit hold placement", e);
+        }
+    }
+
+    private Mono<DebitHoldResponse> placeDebitHoldAsync(String accountId,
+                                                        String holdId,
+                                                        BigDecimal amount,
+                                                        String transactionId,
+                                                        String reason) {
+        String serviceToken = generateInternalServiceToken();
+        DebitHoldRequest request = new DebitHoldRequest(holdId, transactionId, amount, reason);
+        return Mono.fromCallable(() -> {
+                    WebClient webClient = webClientBuilder.baseUrl(accountServiceBaseUrl).build();
+                    return webClient.post()
+                            .uri("/api/internal/accounts/{id}/holds", accountId)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + serviceToken)
+                            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                            .bodyValue(request)
+                            .retrieve()
+                            .bodyToMono(DebitHoldResponse.class)
+                            .timeout(Duration.ofMillis(timeout))
+                            .block();
+                })
+                .subscribeOn(Schedulers.boundedElastic())
+                .transformDeferred(RetryOperator.of(accountServiceRetry))
+                .transformDeferred(CircuitBreakerOperator.of(accountServiceCircuitBreaker))
+                .transformDeferred(TimeLimiterOperator.of(accountServiceTimeLimiter));
+    }
+
+    @CacheEvict(value = "account:validation", key = "#accountId")
+    public DebitHoldResponse captureDebitHold(String accountId,
+                                              String holdId,
+                                              String transactionId,
+                                              String reason) {
+        try {
+            return transitionDebitHoldAsync(accountId, holdId, transactionId, reason, true).block();
+        } catch (Exception e) {
+            throw mapServiceException("debit hold capture", e);
+        }
+    }
+
+    @CacheEvict(value = "account:validation", key = "#accountId")
+    public DebitHoldResponse releaseDebitHold(String accountId,
+                                              String holdId,
+                                              String transactionId,
+                                              String reason) {
+        try {
+            return transitionDebitHoldAsync(accountId, holdId, transactionId, reason, false).block();
+        } catch (Exception e) {
+            throw mapServiceException("debit hold release", e);
+        }
+    }
+
+    private Mono<DebitHoldResponse> transitionDebitHoldAsync(String accountId,
+                                                             String holdId,
+                                                             String transactionId,
+                                                             String reason,
+                                                             boolean capture) {
+        String serviceToken = generateInternalServiceToken();
+        HoldTransitionRequest request = new HoldTransitionRequest(transactionId, reason);
+        String action = capture ? "capture" : "release";
+        return Mono.fromCallable(() -> {
+                    WebClient webClient = webClientBuilder.baseUrl(accountServiceBaseUrl).build();
+                    return webClient.post()
+                            .uri("/api/internal/accounts/{id}/holds/{holdId}/{action}", accountId, holdId, action)
+                            .header(HttpHeaders.AUTHORIZATION, "Bearer " + serviceToken)
+                            .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                            .bodyValue(request)
+                            .retrieve()
+                            .bodyToMono(DebitHoldResponse.class)
+                            .timeout(Duration.ofMillis(timeout))
+                            .block();
+                })
+                .subscribeOn(Schedulers.boundedElastic())
+                .transformDeferred(RetryOperator.of(accountServiceRetry))
+                .transformDeferred(CircuitBreakerOperator.of(accountServiceCircuitBreaker))
+                .transformDeferred(TimeLimiterOperator.of(accountServiceTimeLimiter));
+    }
+
     public boolean validateAccount(String accountId) {
         try {
             AccountDto account = getAccount(accountId);
@@ -199,7 +287,7 @@ public class ResilientAccountServiceClient {
             BigDecimal availableCredit = account.getAvailableCredit();
             return availableCredit != null && availableCredit.compareTo(amount) >= 0;
         }
-        return account.getBalance().compareTo(amount) >= 0;
+        return account.spendableBalance().compareTo(amount) >= 0;
     }
 
     public boolean checkHealth() {
@@ -309,6 +397,44 @@ public class ResilientAccountServiceClient {
         public BalanceOperationResponse(Long accountId, String operationId, boolean applied,
                                         BigDecimal newBalance, Long version, String status) {
             this(accountId, operationId, applied, newBalance, version, status, null);
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DebitHoldRequest {
+        private String holdId;
+        private String transactionId;
+        private BigDecimal amount;
+        private String reason;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HoldTransitionRequest {
+        private String transactionId;
+        private String reason;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DebitHoldResponse {
+        private String holdId;
+        private Long accountId;
+        private boolean applied;
+        private BigDecimal ledgerBalance;
+        private BigDecimal availableBalance;
+        private Long version;
+        private String status;
+        private String message;
+
+        public DebitHoldResponse(String holdId, Long accountId, boolean applied,
+                                 BigDecimal ledgerBalance, BigDecimal availableBalance,
+                                 String status, String message) {
+            this(holdId, accountId, applied, ledgerBalance, availableBalance, null, status, message);
         }
     }
 }

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/AccountDto.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/dto/AccountDto.java
@@ -11,22 +11,38 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 @Builder
 public class AccountDto {
-    
+
     private Long id;
     private String ownerId;
     private BigDecimal balance;
+    private BigDecimal ledgerBalance;
+    private BigDecimal availableBalance;
     private String accountType;
     private Boolean active;
     private String status;
-    
+
     // Credit card specific fields
     private BigDecimal creditLimit;
     private BigDecimal availableCredit;
-    
+
     // Savings account specific fields
     private BigDecimal interestRate;
 
     public boolean allowsDebits() {
         return status == null || status.isBlank() || "ACTIVE".equalsIgnoreCase(status);
+    }
+
+    public BigDecimal spendableBalance() {
+        if (availableBalance != null) {
+            return availableBalance;
+        }
+        return balance != null ? balance : BigDecimal.ZERO;
+    }
+
+    public BigDecimal ledgerBalanceOrBalance() {
+        if (ledgerBalance != null) {
+            return ledgerBalance;
+        }
+        return balance != null ? balance : BigDecimal.ZERO;
     }
 }

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/entity/TransactionProcessingState.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/entity/TransactionProcessingState.java
@@ -2,6 +2,9 @@ package com.suhasan.finance.transaction_service.entity;
 
 public enum TransactionProcessingState {
     INITIATED("Transaction has been created and processing started"),
+    HOLD_PLACED("Debit authorization hold has been placed"),
+    HOLD_CAPTURED("Debit authorization hold has been captured"),
+    HOLD_RELEASED("Debit authorization hold has been released"),
     DEBIT_APPLIED("Debit side of transaction has been applied"),
     CREDIT_APPLIED("Credit side of transaction has been applied"),
     COMPLETED("Transaction processing completed"),

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/service/TransactionServiceImpl.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/service/TransactionServiceImpl.java
@@ -33,6 +33,7 @@ import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -77,7 +78,7 @@ public class TransactionServiceImpl implements TransactionService {
             throw new IllegalArgumentException("Transaction exceeds limits");
         }
 
-        if (fromAccount.getBalance().compareTo(request.getAmount()) < 0) {
+        if (fromAccount.spendableBalance().compareTo(request.getAmount()) < 0) {
             throw new IllegalArgumentException("Insufficient funds");
         }
 
@@ -94,7 +95,7 @@ public class TransactionServiceImpl implements TransactionService {
                 .reference(request.getReference())
                 .idempotencyKey(normalizedIdempotencyKey)
                 .createdBy(userId)
-                .fromAccountBalanceBefore(fromAccount.getBalance())
+                .fromAccountBalanceBefore(fromAccount.ledgerBalanceOrBalance())
                 .build();
         try {
             transaction = transactionRepository.save(transaction);
@@ -113,26 +114,46 @@ public class TransactionServiceImpl implements TransactionService {
                 request.getFromAccountId(), request.getToAccountId(), request.getAmount(), userId);
         metricsService.recordTransactionInitiated(TransactionType.TRANSFER);
 
-        boolean debitApplied = false;
+        boolean holdPlaced = false;
+        boolean holdCaptured = false;
+        String holdId = transaction.getTransactionId() + ":hold";
         try {
-            ResilientAccountServiceClient.BalanceOperationResponse debitResult = accountServiceClient
-                    .applyBalanceOperation(
+            ResilientAccountServiceClient.DebitHoldResponse holdResult = accountServiceClient
+                    .placeDebitHold(
                             request.getFromAccountId(),
-                            transactionId + ":debit",
-                            request.getAmount().negate(),
-                            transactionId,
-                            "TRANSFER_DEBIT",
-                            false);
-            debitApplied = debitResult.isApplied();
-            transaction.setFromAccountBalanceAfter(debitResult.getNewBalance());
-            transaction.setProcessingState(TransactionProcessingState.DEBIT_APPLIED);
+                            holdId,
+                            request.getAmount(),
+                            transaction.getTransactionId(),
+                            "TRANSFER_HOLD");
+            transaction.setProcessingState(TransactionProcessingState.HOLD_PLACED);
             transactionRepository.save(transaction);
-            if (!debitResult.isApplied()) {
+            if (!holdResult.isApplied()) {
                 transaction.setStatus(TransactionStatus.FAILED);
                 transaction.setProcessedAt(LocalDateTime.now());
                 transactionRepository.save(transaction);
-                throw new IllegalArgumentException(firstNonBlank(debitResult.getMessage(), "Insufficient funds"));
+                logDebitHoldEvent("DEBIT_HOLD_REJECTED", transaction, firstNonBlank(holdResult.getMessage(), "Insufficient funds"));
+                throw new IllegalArgumentException(firstNonBlank(holdResult.getMessage(), "Insufficient funds"));
             }
+            holdPlaced = true;
+            logDebitHoldEvent("DEBIT_HOLD_PLACED", transaction, null);
+
+            ResilientAccountServiceClient.DebitHoldResponse captureResult = accountServiceClient
+                    .captureDebitHold(
+                            request.getFromAccountId(),
+                            holdId,
+                            transaction.getTransactionId(),
+                            "TRANSFER_CAPTURE");
+            if (!captureResult.isApplied()) {
+                transaction.setStatus(TransactionStatus.FAILED);
+                transaction.setProcessedAt(LocalDateTime.now());
+                transactionRepository.save(transaction);
+                throw new IllegalArgumentException(firstNonBlank(captureResult.getMessage(), "Debit hold capture failed"));
+            }
+            holdCaptured = true;
+            transaction.setFromAccountBalanceAfter(captureResult.getLedgerBalance());
+            transaction.setProcessingState(TransactionProcessingState.HOLD_CAPTURED);
+            transactionRepository.save(transaction);
+            logDebitHoldEvent("DEBIT_HOLD_CAPTURED", transaction, null);
 
             ResilientAccountServiceClient.BalanceOperationResponse creditResult = accountServiceClient
                     .applyBalanceOperation(
@@ -157,7 +178,7 @@ public class TransactionServiceImpl implements TransactionService {
                     TransactionStatus.COMPLETED, request.getAmount(), processingTime);
             return mapToResponse(transaction);
         } catch (Exception e) {
-            if (debitApplied) {
+            if (holdCaptured) {
                 try {
                     accountServiceClient.applyBalanceOperation(
                             request.getFromAccountId(),
@@ -169,9 +190,17 @@ public class TransactionServiceImpl implements TransactionService {
                     transaction.setProcessingState(TransactionProcessingState.COMPENSATED);
                     transaction.setStatus(TransactionStatus.FAILED);
                 } catch (Exception compensationError) {
-                    transaction.setProcessingState(TransactionProcessingState.MANUAL_ACTION_REQUIRED);
-                    transaction.setStatus(TransactionStatus.FAILED_REQUIRES_MANUAL_ACTION);
+                transaction.setProcessingState(TransactionProcessingState.MANUAL_ACTION_REQUIRED);
+                transaction.setStatus(TransactionStatus.FAILED_REQUIRES_MANUAL_ACTION);
                 }
+            } else if (holdPlaced) {
+                releasePlacedHoldAfterFailure(
+                        request.getFromAccountId(),
+                        holdId,
+                        transaction,
+                        "TRANSFER_CAPTURE_FAILED",
+                        e.getMessage());
+                transaction.setStatus(TransactionStatus.FAILED);
             } else {
                 transaction.setStatus(TransactionStatus.FAILED);
             }
@@ -220,7 +249,7 @@ public class TransactionServiceImpl implements TransactionService {
                 .reference(reference)
                 .idempotencyKey(normalizedIdempotencyKey)
                 .createdBy(userId)
-                .toAccountBalanceBefore(account.getBalance())
+                .toAccountBalanceBefore(account.ledgerBalanceOrBalance())
                 .build();
         try {
             transaction = transactionRepository.save(transaction);
@@ -281,7 +310,7 @@ public class TransactionServiceImpl implements TransactionService {
         if (!validateTransactionLimits(accountId, account.getAccountType(), TransactionType.WITHDRAWAL, amount)) {
             throw new IllegalArgumentException("Transaction exceeds limits");
         }
-        if (account.getBalance().compareTo(amount) < 0) {
+        if (account.spendableBalance().compareTo(amount) < 0) {
             throw new IllegalArgumentException("Insufficient funds");
         }
 
@@ -297,7 +326,7 @@ public class TransactionServiceImpl implements TransactionService {
                 .reference(reference)
                 .idempotencyKey(normalizedIdempotencyKey)
                 .createdBy(userId)
-                .fromAccountBalanceBefore(account.getBalance())
+                .fromAccountBalanceBefore(account.ledgerBalanceOrBalance())
                 .build();
         try {
             transaction = transactionRepository.save(transaction);
@@ -310,30 +339,52 @@ public class TransactionServiceImpl implements TransactionService {
                             "Idempotency conflict but record not found — manual review required"));
         }
 
+        boolean holdPlaced = false;
+        boolean holdCaptured = false;
+        String holdId = transaction.getTransactionId() + ":hold";
         try {
-            ResilientAccountServiceClient.BalanceOperationResponse response = accountServiceClient
-                    .applyBalanceOperation(
+            ResilientAccountServiceClient.DebitHoldResponse hold = accountServiceClient
+                    .placeDebitHold(
                             accountId,
-                            transaction.getTransactionId() + ":withdrawal",
-                            amount.negate(),
+                            holdId,
+                            amount,
                             transaction.getTransactionId(),
-                            "WITHDRAWAL",
-                            false);
-            if (!response.isApplied()) {
+                            "WITHDRAWAL_HOLD");
+            transaction.setProcessingState(TransactionProcessingState.HOLD_PLACED);
+            transactionRepository.save(transaction);
+            if (!hold.isApplied()) {
                 transaction.setStatus(TransactionStatus.FAILED);
                 transaction.setProcessedAt(LocalDateTime.now());
                 transactionRepository.save(transaction);
-                throw new IllegalArgumentException(firstNonBlank(response.getMessage(), "Insufficient funds"));
+                logDebitHoldEvent("DEBIT_HOLD_REJECTED", transaction, firstNonBlank(hold.getMessage(), "Insufficient funds"));
+                throw new IllegalArgumentException(firstNonBlank(hold.getMessage(), "Insufficient funds"));
             }
-            transaction.setFromAccountBalanceAfter(response.getNewBalance());
+            holdPlaced = true;
+            logDebitHoldEvent("DEBIT_HOLD_PLACED", transaction, null);
+            ResilientAccountServiceClient.DebitHoldResponse capture = accountServiceClient
+                    .captureDebitHold(accountId, holdId, transaction.getTransactionId(), "WITHDRAWAL_CAPTURE");
+            if (!capture.isApplied()) {
+                transaction.setStatus(TransactionStatus.FAILED);
+                transaction.setProcessedAt(LocalDateTime.now());
+                transactionRepository.save(transaction);
+                throw new IllegalArgumentException(firstNonBlank(capture.getMessage(), "Debit hold capture failed"));
+            }
+            holdCaptured = true;
+            transaction.setFromAccountBalanceAfter(capture.getLedgerBalance());
             transaction.setStatus(TransactionStatus.COMPLETED);
             transaction.setProcessedBy("SYSTEM");
             transaction.setProcessedAt(LocalDateTime.now());
+            transaction.setProcessingState(TransactionProcessingState.HOLD_CAPTURED);
+            transactionRepository.save(transaction);
+            logDebitHoldEvent("DEBIT_HOLD_CAPTURED", transaction, null);
             transaction.setProcessingState(TransactionProcessingState.COMPLETED);
             transaction = transactionRepository.save(transaction);
             riskEvaluationService.evaluateCompletedTransaction(transaction);
             return mapToResponse(transaction);
         } catch (Exception e) {
+            if (holdPlaced && !holdCaptured) {
+                releasePlacedHoldAfterFailure(accountId, holdId, transaction, "WITHDRAWAL_CAPTURE_FAILED", e.getMessage());
+            }
             if (transaction.getStatus() != TransactionStatus.COMPLETED) {
                 transaction.setStatus(TransactionStatus.FAILED);
                 transaction.setProcessedAt(LocalDateTime.now());
@@ -885,6 +936,36 @@ public class TransactionServiceImpl implements TransactionService {
 
     private String firstNonBlank(String value, String fallback) {
         return value == null || value.isBlank() ? fallback : value;
+    }
+
+    private void logDebitHoldEvent(String eventType, Transaction transaction, String message) {
+        auditService.logSystemEvent(eventType, "transaction-service",
+                firstNonBlank(message, eventType + " for transaction " + transaction.getTransactionId()),
+                Map.of(
+                        "transactionId", transaction.getTransactionId(),
+                        "fromAccountId", firstNonBlank(transaction.getFromAccountId(), ""),
+                        "toAccountId", firstNonBlank(transaction.getToAccountId(), ""),
+                        "amount", transaction.getAmount() != null ? transaction.getAmount().toPlainString() : ""));
+    }
+
+    private void releasePlacedHoldAfterFailure(String accountId, String holdId, Transaction transaction,
+                                               String reason, String failureMessage) {
+        logDebitHoldEvent("DEBIT_HOLD_REJECTED", transaction,
+                firstNonBlank(failureMessage, "Debit hold capture failed"));
+        try {
+            ResilientAccountServiceClient.DebitHoldResponse releaseResult = accountServiceClient.releaseDebitHold(
+                    accountId,
+                    holdId,
+                    transaction.getTransactionId(),
+                    reason);
+            if (releaseResult.isApplied()) {
+                transaction.setProcessingState(TransactionProcessingState.HOLD_RELEASED);
+                logDebitHoldEvent("DEBIT_HOLD_RELEASED", transaction, null);
+            }
+        } catch (Exception releaseError) {
+            log.warn("Debit hold release failed for transaction {} and hold {}: {}",
+                    transaction.getTransactionId(), holdId, releaseError.getMessage());
+        }
     }
 
     private void assertCanAccessAccountScope(String accountId) {

--- a/transaction-service/src/test/java/com/suhasan/finance/transaction_service/service/IdempotencyAndReversalTest.java
+++ b/transaction-service/src/test/java/com/suhasan/finance/transaction_service/service/IdempotencyAndReversalTest.java
@@ -173,9 +173,12 @@ class IdempotencyAndReversalTest {
                                         .thenReturn(accountDto(ACCOUNT_B, BigDecimal.valueOf(500)));
                         var savedTx = completedTransfer(null);
                         when(transactionRepository.save(any())).thenReturn(savedTx);
-                        when(accountServiceClient.applyBalanceOperation(eq(ACCOUNT_A), anyString(),
-                                        eq(BigDecimal.valueOf(-100)), anyString(), eq("TRANSFER_DEBIT"), eq(false)))
-                                        .thenReturn(balanceOpResponse(ACCOUNT_A));
+                        when(accountServiceClient.placeDebitHold(eq(ACCOUNT_A), anyString(),
+                                        eq(BigDecimal.valueOf(100)), anyString(), eq("TRANSFER_HOLD")))
+                                        .thenReturn(debitHoldResponse(ACCOUNT_A, "PLACED"));
+                        when(accountServiceClient.captureDebitHold(eq(ACCOUNT_A), anyString(), anyString(),
+                                        eq("TRANSFER_CAPTURE")))
+                                        .thenReturn(debitHoldResponse(ACCOUNT_A, "CAPTURED"));
                         when(accountServiceClient.applyBalanceOperation(eq(ACCOUNT_B), anyString(),
                                         eq(BigDecimal.valueOf(100)), anyString(), eq("TRANSFER_CREDIT"), eq(true)))
                                         .thenReturn(balanceOpResponse(ACCOUNT_B));
@@ -495,6 +498,8 @@ class IdempotencyAndReversalTest {
                 return com.suhasan.finance.transaction_service.dto.AccountDto.builder()
                                 .id((long) id.hashCode())
                                 .balance(balance)
+                                .ledgerBalance(balance)
+                                .availableBalance(balance)
                                 .accountType("CHECKING")
                                 .availableCredit(BigDecimal.ZERO)
                                 .build();
@@ -530,5 +535,11 @@ class IdempotencyAndReversalTest {
                 return new ResilientAccountServiceClient.BalanceOperationResponse(
                                 (long) accountId.hashCode(), "op-" + accountId, true,
                                 BigDecimal.valueOf(900), 1L, "APPLIED");
+        }
+
+        private ResilientAccountServiceClient.DebitHoldResponse debitHoldResponse(String accountId, String status) {
+                return new ResilientAccountServiceClient.DebitHoldResponse(
+                                "hold-" + accountId, (long) accountId.hashCode(), true,
+                                BigDecimal.valueOf(900), BigDecimal.valueOf(900), status, null);
         }
 }

--- a/transaction-service/src/test/java/com/suhasan/finance/transaction_service/service/TransactionServiceImplTest.java
+++ b/transaction-service/src/test/java/com/suhasan/finance/transaction_service/service/TransactionServiceImplTest.java
@@ -80,6 +80,8 @@ class TransactionServiceImplTest {
                 fromAccount = AccountDto.builder()
                                 .id(1L)
                                 .balance(BigDecimal.valueOf(1000))
+                                .ledgerBalance(BigDecimal.valueOf(1000))
+                                .availableBalance(BigDecimal.valueOf(1000))
                                 .accountType("CHECKING")
                                 .availableCredit(BigDecimal.ZERO)
                                 .build();
@@ -87,6 +89,8 @@ class TransactionServiceImplTest {
                 toAccount = AccountDto.builder()
                                 .id(2L)
                                 .balance(BigDecimal.valueOf(500))
+                                .ledgerBalance(BigDecimal.valueOf(500))
+                                .availableBalance(BigDecimal.valueOf(500))
                                 .accountType("SAVINGS")
                                 .availableCredit(BigDecimal.ZERO)
                                 .build();
@@ -115,11 +119,16 @@ class TransactionServiceImplTest {
                 when(accountServiceClient.getAccount("acc1")).thenReturn(fromAccount);
                 when(accountServiceClient.getAccount("acc2")).thenReturn(toAccount);
                 when(transactionRepository.save(any(Transaction.class))).thenReturn(transaction);
-                when(accountServiceClient.applyBalanceOperation(eq("acc1"), anyString(), eq(BigDecimal.valueOf(-100)),
-                                anyString(), eq("TRANSFER_DEBIT"), eq(false)))
-                                .thenReturn(new ResilientAccountServiceClient.BalanceOperationResponse(1L, "op-debit",
-                                                true,
-                                                BigDecimal.valueOf(900), 1L, "APPLIED"));
+                when(accountServiceClient.placeDebitHold(eq("acc1"), anyString(), eq(BigDecimal.valueOf(100)),
+                                anyString(), eq("TRANSFER_HOLD")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-transfer",
+                                                1L, true, BigDecimal.valueOf(1000), BigDecimal.valueOf(900),
+                                                "PLACED", null));
+                when(accountServiceClient.captureDebitHold(eq("acc1"), anyString(), anyString(),
+                                eq("TRANSFER_CAPTURE")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-transfer",
+                                                1L, true, BigDecimal.valueOf(900), BigDecimal.valueOf(900),
+                                                "CAPTURED", null));
                 when(accountServiceClient.applyBalanceOperation(eq("acc2"), anyString(), eq(BigDecimal.valueOf(100)),
                                 anyString(), eq("TRANSFER_CREDIT"), eq(true)))
                                 .thenReturn(new ResilientAccountServiceClient.BalanceOperationResponse(2L, "op-credit",
@@ -136,9 +145,11 @@ class TransactionServiceImplTest {
                 assertEquals(TransactionStatus.COMPLETED, result.getStatus());
 
                 verify(accountServiceClient).getAccount("acc1");
-                verify(accountServiceClient).applyBalanceOperation(eq("acc1"), anyString(),
-                                eq(BigDecimal.valueOf(-100)),
-                                anyString(), eq("TRANSFER_DEBIT"), eq(false));
+                verify(accountServiceClient).placeDebitHold(eq("acc1"), anyString(),
+                                eq(BigDecimal.valueOf(100)),
+                                anyString(), eq("TRANSFER_HOLD"));
+                verify(accountServiceClient).captureDebitHold(eq("acc1"), anyString(),
+                                anyString(), eq("TRANSFER_CAPTURE"));
                 verify(accountServiceClient).applyBalanceOperation(eq("acc2"), anyString(), eq(BigDecimal.valueOf(100)),
                                 anyString(), eq("TRANSFER_CREDIT"), eq(true));
                 verify(transactionRepository, atLeast(2)).save(any(Transaction.class));
@@ -161,26 +172,66 @@ class TransactionServiceImplTest {
 
         @Test
         void processTransfer_ToAccountNotFound() {
-                // Arrange
                 when(accountServiceClient.getAccount("acc1")).thenReturn(fromAccount);
-                when(accountServiceClient.applyBalanceOperation(eq("acc1"), anyString(), eq(BigDecimal.valueOf(-100)),
-                                anyString(), eq("TRANSFER_DEBIT"), eq(false)))
-                                .thenReturn(new ResilientAccountServiceClient.BalanceOperationResponse(1L, "op-debit",
-                                                true,
-                                                BigDecimal.valueOf(900), 1L, "APPLIED"));
+                when(transactionRepository.save(any(Transaction.class))).thenReturn(transaction);
+                when(accountServiceClient.placeDebitHold(eq("acc1"), anyString(), eq(BigDecimal.valueOf(100)),
+                                anyString(), eq("TRANSFER_HOLD")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-transfer",
+                                                1L, true, BigDecimal.valueOf(1000), BigDecimal.valueOf(900),
+                                                "PLACED", null));
+                when(accountServiceClient.captureDebitHold(eq("acc1"), anyString(), anyString(),
+                                eq("TRANSFER_CAPTURE")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-transfer",
+                                                1L, true, BigDecimal.valueOf(900), BigDecimal.valueOf(900),
+                                                "CAPTURED", null));
                 when(accountServiceClient.applyBalanceOperation(eq("acc2"), anyString(), eq(BigDecimal.valueOf(100)),
                                 anyString(), eq("TRANSFER_CREDIT"), eq(true)))
                                 .thenThrow(new RuntimeException("To account not found"));
 
-                // Act & Assert
                 assertThrows(RuntimeException.class,
                                 () -> transactionService.processTransfer(transferRequest, userId, null));
+                verify(accountServiceClient).applyBalanceOperation(eq("acc1"), anyString(), eq(BigDecimal.valueOf(100)),
+                                anyString(), eq("TRANSFER_COMPENSATION"), eq(true));
+        }
+
+        @Test
+        void processTransfer_CaptureFailureReleasesHoldAndAuditsFailure() {
+                when(accountServiceClient.getAccount("acc1")).thenReturn(fromAccount);
+                when(accountServiceClient.getAccount("acc2")).thenReturn(toAccount);
+                when(transactionRepository.save(any(Transaction.class))).thenReturn(transaction);
+                when(accountServiceClient.placeDebitHold(eq("acc1"), anyString(), eq(BigDecimal.valueOf(100)),
+                                anyString(), eq("TRANSFER_HOLD")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-transfer",
+                                                1L, true, BigDecimal.valueOf(1000), BigDecimal.valueOf(900),
+                                                "PLACED", null));
+                when(accountServiceClient.captureDebitHold(eq("acc1"), anyString(), anyString(),
+                                eq("TRANSFER_CAPTURE")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-transfer",
+                                                1L, false, BigDecimal.valueOf(1000), BigDecimal.valueOf(900),
+                                                "PLACED", "Capture unavailable"));
+                when(accountServiceClient.releaseDebitHold(eq("acc1"), anyString(), anyString(),
+                                eq("TRANSFER_CAPTURE_FAILED")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-transfer",
+                                                1L, true, BigDecimal.valueOf(1000), BigDecimal.valueOf(1000),
+                                                "RELEASED", null));
+
+                RuntimeException exception = assertThrows(RuntimeException.class,
+                                () -> transactionService.processTransfer(transferRequest, userId, null));
+
+                assertTrue(exception.getMessage().contains("Capture unavailable"));
+                verify(accountServiceClient).releaseDebitHold(eq("acc1"), anyString(), anyString(),
+                                eq("TRANSFER_CAPTURE_FAILED"));
+                verify(auditService).logSystemEvent(eq("DEBIT_HOLD_REJECTED"), eq("transaction-service"),
+                                contains("Capture unavailable"), anyMap());
+                verify(auditService).logSystemEvent(eq("DEBIT_HOLD_RELEASED"), eq("transaction-service"),
+                                anyString(), anyMap());
         }
 
         @Test
         void processTransfer_InsufficientFunds() {
                 // Arrange
-                fromAccount.setBalance(BigDecimal.valueOf(50)); // Less than transfer amount
+                fromAccount.setBalance(BigDecimal.valueOf(1000));
+                fromAccount.setAvailableBalance(BigDecimal.valueOf(50)); // Less than transfer amount
                 when(accountServiceClient.getAccount("acc1")).thenReturn(fromAccount);
                 when(accountServiceClient.getAccount("acc2")).thenReturn(toAccount);
 
@@ -189,6 +240,35 @@ class TransactionServiceImplTest {
                                 () -> transactionService.processTransfer(transferRequest, userId, null));
 
                 assertEquals("Insufficient funds", exception.getMessage());
+        }
+
+        @Test
+        void processTransfer_MissingAvailableBalanceFallsBackToBalance() {
+                fromAccount.setAvailableBalance(null);
+                fromAccount.setBalance(BigDecimal.valueOf(1000));
+                when(accountServiceClient.getAccount("acc1")).thenReturn(fromAccount);
+                when(accountServiceClient.getAccount("acc2")).thenReturn(toAccount);
+                when(transactionRepository.save(any(Transaction.class))).thenReturn(transaction);
+                when(accountServiceClient.placeDebitHold(eq("acc1"), anyString(), eq(BigDecimal.valueOf(100)),
+                                anyString(), eq("TRANSFER_HOLD")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-transfer",
+                                                1L, true, BigDecimal.valueOf(1000), BigDecimal.valueOf(900),
+                                                "PLACED", null));
+                when(accountServiceClient.captureDebitHold(eq("acc1"), anyString(), anyString(),
+                                eq("TRANSFER_CAPTURE")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-transfer",
+                                                1L, true, BigDecimal.valueOf(900), BigDecimal.valueOf(900),
+                                                "CAPTURED", null));
+                when(accountServiceClient.applyBalanceOperation(eq("acc2"), anyString(), eq(BigDecimal.valueOf(100)),
+                                anyString(), eq("TRANSFER_CREDIT"), eq(true)))
+                                .thenReturn(new ResilientAccountServiceClient.BalanceOperationResponse(2L, "op-credit",
+                                                true, BigDecimal.valueOf(600), 1L, "APPLIED"));
+
+                TransactionResponse result = transactionService.processTransfer(transferRequest, userId, null);
+
+                assertNotNull(result);
+                verify(accountServiceClient).placeDebitHold(eq("acc1"), anyString(), eq(BigDecimal.valueOf(100)),
+                                anyString(), eq("TRANSFER_HOLD"));
         }
 
         @Test
@@ -212,11 +292,16 @@ class TransactionServiceImplTest {
                 when(accountServiceClient.getAccount("acc1")).thenReturn(fromAccount);
                 when(accountServiceClient.getAccount("acc2")).thenReturn(toAccount);
                 when(transactionRepository.save(any(Transaction.class))).thenReturn(transaction);
-                when(accountServiceClient.applyBalanceOperation(eq("acc1"), anyString(), eq(BigDecimal.valueOf(-100)),
-                                anyString(), eq("TRANSFER_DEBIT"), eq(false)))
-                                .thenReturn(new ResilientAccountServiceClient.BalanceOperationResponse(1L, "op-debit",
-                                                true,
-                                                BigDecimal.valueOf(900), 1L, "APPLIED", null));
+                when(accountServiceClient.placeDebitHold(eq("acc1"), anyString(), eq(BigDecimal.valueOf(100)),
+                                anyString(), eq("TRANSFER_HOLD")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-transfer",
+                                                1L, true, BigDecimal.valueOf(1000), BigDecimal.valueOf(900),
+                                                "PLACED", null));
+                when(accountServiceClient.captureDebitHold(eq("acc1"), anyString(), anyString(),
+                                eq("TRANSFER_CAPTURE")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-transfer",
+                                                1L, true, BigDecimal.valueOf(900), BigDecimal.valueOf(900),
+                                                "CAPTURED", null));
                 when(accountServiceClient.applyBalanceOperation(eq("acc2"), anyString(), eq(BigDecimal.valueOf(100)),
                                 anyString(), eq("TRANSFER_CREDIT"), eq(true)))
                                 .thenReturn(new ResilientAccountServiceClient.BalanceOperationResponse(2L, "op-credit",
@@ -321,12 +406,16 @@ class TransactionServiceImplTest {
 
                 when(accountServiceClient.getAccount(accountId)).thenReturn(fromAccount);
                 when(transactionRepository.save(any(Transaction.class))).thenReturn(transaction);
-                when(accountServiceClient.applyBalanceOperation(eq(accountId), anyString(), eq(amount.negate()),
-                                anyString(),
-                                eq("WITHDRAWAL"), eq(false)))
-                                .thenReturn(new ResilientAccountServiceClient.BalanceOperationResponse(1L,
-                                                "op-withdraw", true,
-                                                BigDecimal.valueOf(800), 1L, "APPLIED"));
+                when(accountServiceClient.placeDebitHold(eq(accountId), anyString(), eq(amount), anyString(),
+                                eq("WITHDRAWAL_HOLD")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-withdraw",
+                                                1L, true, BigDecimal.valueOf(1000), BigDecimal.valueOf(800),
+                                                "PLACED", null));
+                when(accountServiceClient.captureDebitHold(eq(accountId), anyString(), anyString(),
+                                eq("WITHDRAWAL_CAPTURE")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-withdraw",
+                                                1L, true, BigDecimal.valueOf(800), BigDecimal.valueOf(800),
+                                                "CAPTURED", null));
 
                 // Act
                 TransactionResponse result = transactionService.processWithdrawal(accountId, amount, description,
@@ -335,10 +424,11 @@ class TransactionServiceImplTest {
                 // Assert
                 assertNotNull(result);
                 verify(accountServiceClient).getAccount(accountId);
-                verify(accountServiceClient).applyBalanceOperation(eq(accountId), anyString(), eq(amount.negate()),
-                                anyString(),
-                                eq("WITHDRAWAL"), eq(false));
-                verify(transactionRepository, times(2)).save(any(Transaction.class));
+                verify(accountServiceClient).placeDebitHold(eq(accountId), anyString(), eq(amount), anyString(),
+                                eq("WITHDRAWAL_HOLD"));
+                verify(accountServiceClient).captureDebitHold(eq(accountId), anyString(), anyString(),
+                                eq("WITHDRAWAL_CAPTURE"));
+                verify(transactionRepository, atLeast(4)).save(any(Transaction.class));
         }
 
         @Test
@@ -374,6 +464,39 @@ class TransactionServiceImplTest {
                                 contains(accountId), isNull());
                 verify(accountServiceClient, never()).applyBalanceOperation(anyString(), anyString(), any(),
                                 anyString(), anyString(), anyBoolean());
+        }
+
+        @Test
+        void processWithdrawal_CaptureFailureReleasesHoldAndAuditsFailure() {
+                String accountId = "acc1";
+                BigDecimal amount = BigDecimal.valueOf(200);
+                when(accountServiceClient.getAccount(accountId)).thenReturn(fromAccount);
+                when(transactionRepository.save(any(Transaction.class))).thenReturn(transaction);
+                when(accountServiceClient.placeDebitHold(eq(accountId), anyString(), eq(amount), anyString(),
+                                eq("WITHDRAWAL_HOLD")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-withdraw",
+                                                1L, true, BigDecimal.valueOf(1000), BigDecimal.valueOf(800),
+                                                "PLACED", null));
+                when(accountServiceClient.captureDebitHold(eq(accountId), anyString(), anyString(),
+                                eq("WITHDRAWAL_CAPTURE")))
+                                .thenThrow(new RuntimeException("Capture service unavailable"));
+                when(accountServiceClient.releaseDebitHold(eq(accountId), anyString(), anyString(),
+                                eq("WITHDRAWAL_CAPTURE_FAILED")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-withdraw",
+                                                1L, true, BigDecimal.valueOf(1000), BigDecimal.valueOf(1000),
+                                                "RELEASED", null));
+
+                RuntimeException exception = assertThrows(RuntimeException.class,
+                                () -> transactionService.processWithdrawal(accountId, amount, "Test withdrawal",
+                                                userId, null));
+
+                assertTrue(exception.getMessage().contains("Capture service unavailable"));
+                verify(accountServiceClient).releaseDebitHold(eq(accountId), anyString(), anyString(),
+                                eq("WITHDRAWAL_CAPTURE_FAILED"));
+                verify(auditService).logSystemEvent(eq("DEBIT_HOLD_REJECTED"), eq("transaction-service"),
+                                contains("Capture service unavailable"), anyMap());
+                verify(auditService).logSystemEvent(eq("DEBIT_HOLD_RELEASED"), eq("transaction-service"),
+                                anyString(), anyMap());
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Adds ledger balance, available balance, and debit hold lifecycle support in account-service.
- Updates transaction-service withdrawal and outgoing transfer flows to place and capture debit holds before completion.
- Updates frontend account, dashboard, admin, and move-money screens to show spendable available balance and enforce debit-source availability.

## Validation
- `mvn -q test` passed before publishing this slice.
- `cd frontend && npm.cmd test` passed before publishing this slice.
- `cd frontend && npm.cmd run lint` passed before publishing this slice.
- `cd frontend && npm.cmd run build` passed before publishing this slice.
- `git diff --cached --check` passed before commit.
- Live browser demo verified hold placement, hold release, available-balance debit blocking, and completed withdrawal balance updates.

## Notes
- This branch is based on the previous account hold/freeze feature branch because pending debit authorization builds on account status enforcement.