### PR TITLE
[codex] add customer notification center

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ financial-backend-services/
 - View transaction details and user transaction stats.
 - Dispute eligible completed transactions from the last 60 days.
 - Review submitted disputes and resolution notes in the customer dispute history.
+- Review in-app notifications, unread counts, and message state for account, transaction, and dispute events.
 
 ### Admin/Ops App
 
@@ -71,6 +72,8 @@ financial-backend-services/
   - Positive balance operations update both ledger and available balances.
   - Account type validation for checking, savings, and credit accounts.
   - Health, metrics, and deployment endpoints.
+  - Customer notification APIs for listing, summary counts, marking one read, and marking all read.
+  - Internal/admin notification creation API secured to `ROLE_ADMIN` and `ROLE_INTERNAL_SERVICE`.
 - Transaction service:
   - Deposit, withdrawal, and transfer endpoints.
   - Frozen-account debit enforcement before withdrawals and outgoing transfer debits.
@@ -87,6 +90,26 @@ financial-backend-services/
   - Customer dispute submission and admin-only dispute queue APIs.
   - Admin-only investigation timeline, summary, and CSV export APIs.
   - Account-service integration for balance updates.
+  - Best-effort account-service notification emission for completed/failed transfer outcomes and dispute lifecycle updates.
+
+## Notification Center
+
+The v1 notification center is in-app only. It does not send email, SMS, push notifications, replies, or attachments.
+
+Customer API:
+
+- `GET /api/notifications?page=&size=&status=&type=&sourceType=&from=&to=`
+- `GET /api/notifications/summary`
+- `PATCH /api/notifications/{notificationId}/read`
+- `PATCH /api/notifications/read-all`
+
+Internal creation API:
+
+- `POST /api/internal/notifications`
+
+Notification records are customer-owned in `account-service`. Customer endpoints always use the authenticated user, while internal/admin callers may create notifications for any `userId`. The internal endpoint requires `ROLE_ADMIN` or `ROLE_INTERNAL_SERVICE`.
+
+Event sources currently create notifications for account freeze/unfreeze, transfer completion/failure, dispute creation, and dispute status changes to `APPROVED`, `DENIED`, or `CLOSED`. Source workflows treat notification delivery as best-effort: failures are logged and do not roll back money movement, account status changes, or dispute updates. Dedupe keys keep repeated source events from creating duplicate inbox rows.
 
 ## Technology Stack
 

--- a/account-service/src/main/java/com/suhasan/finance/account_service/controller/NotificationController.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/controller/NotificationController.java
@@ -1,0 +1,91 @@
+package com.suhasan.finance.account_service.controller;
+
+import com.suhasan.finance.account_service.dto.NotificationCreateRequest;
+import com.suhasan.finance.account_service.dto.NotificationFilter;
+import com.suhasan.finance.account_service.entity.Notification;
+import com.suhasan.finance.account_service.entity.NotificationSeverity;
+import com.suhasan.finance.account_service.entity.NotificationSourceType;
+import com.suhasan.finance.account_service.entity.NotificationStatus;
+import com.suhasan.finance.account_service.entity.NotificationType;
+import com.suhasan.finance.account_service.service.NotificationService;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Dependencies are injected and managed by Spring")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping("/notifications")
+    public ResponseEntity<Page<Notification>> list(
+            @RequestParam(required = false) NotificationStatus status,
+            @RequestParam(required = false) NotificationType type,
+            @RequestParam(required = false) NotificationSeverity severity,
+            @RequestParam(required = false) NotificationSourceType sourceType,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
+            @PageableDefault(size = 20, sort = "createdAt") Pageable pageable,
+            Authentication authentication
+    ) {
+        NotificationFilter filter = new NotificationFilter(status, type, severity, sourceType, from, to);
+        return ResponseEntity.ok(notificationService.listForUser(authentication.getName(), filter, pageable));
+    }
+
+    @GetMapping("/notifications/summary")
+    public ResponseEntity<Map<String, Object>> summary(Authentication authentication) {
+        return ResponseEntity.ok(notificationService.summaryForUser(authentication.getName()));
+    }
+
+    @PatchMapping("/notifications/{notificationId}/read")
+    public ResponseEntity<Notification> markRead(@PathVariable Long notificationId, Authentication authentication) {
+        return ResponseEntity.ok(notificationService.markRead(notificationId, authentication.getName()));
+    }
+
+    @PatchMapping("/notifications/read-all")
+    public ResponseEntity<Map<String, Integer>> markAllRead(Authentication authentication) {
+        return ResponseEntity.ok(Map.of("updated", notificationService.markAllRead(authentication.getName())));
+    }
+
+    @PostMapping("/internal/notifications")
+    public ResponseEntity<Notification> createInternal(
+            @RequestBody NotificationCreateRequest request,
+            Authentication authentication
+    ) {
+        if (!isAdmin(authentication) && !isInternalService(authentication)) {
+            throw new AccessDeniedException("Only admins or internal services can create notifications");
+        }
+        return ResponseEntity.status(HttpStatus.CREATED).body(notificationService.createInternal(request));
+    }
+
+    private boolean isAdmin(Authentication authentication) {
+        return authentication.getAuthorities().stream()
+                .anyMatch(a -> "ROLE_ADMIN".equals(a.getAuthority()));
+    }
+
+    private boolean isInternalService(Authentication authentication) {
+        return authentication.getAuthorities().stream()
+                .anyMatch(a -> "ROLE_INTERNAL_SERVICE".equals(a.getAuthority()));
+    }
+}

--- a/account-service/src/main/java/com/suhasan/finance/account_service/dto/NotificationCreateRequest.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/dto/NotificationCreateRequest.java
@@ -1,0 +1,24 @@
+package com.suhasan.finance.account_service.dto;
+
+import com.suhasan.finance.account_service.entity.NotificationSeverity;
+import com.suhasan.finance.account_service.entity.NotificationSourceType;
+import com.suhasan.finance.account_service.entity.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationCreateRequest {
+    private String userId;
+    private NotificationType type;
+    private NotificationSeverity severity;
+    private String title;
+    private String message;
+    private NotificationSourceType sourceType;
+    private String sourceId;
+    private String dedupeKey;
+}

--- a/account-service/src/main/java/com/suhasan/finance/account_service/dto/NotificationFilter.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/dto/NotificationFilter.java
@@ -1,0 +1,23 @@
+package com.suhasan.finance.account_service.dto;
+
+import com.suhasan.finance.account_service.entity.NotificationSeverity;
+import com.suhasan.finance.account_service.entity.NotificationSourceType;
+import com.suhasan.finance.account_service.entity.NotificationStatus;
+import com.suhasan.finance.account_service.entity.NotificationType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationFilter {
+    private NotificationStatus status;
+    private NotificationType type;
+    private NotificationSeverity severity;
+    private NotificationSourceType sourceType;
+    private LocalDateTime from;
+    private LocalDateTime to;
+}

--- a/account-service/src/main/java/com/suhasan/finance/account_service/entity/Notification.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/entity/Notification.java
@@ -1,0 +1,77 @@
+package com.suhasan.finance.account_service.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long notificationId;
+
+    @Column(nullable = false, length = 100)
+    private String userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private NotificationType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private NotificationSeverity severity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private NotificationStatus status;
+
+    @Column(nullable = false, length = 160)
+    private String title;
+
+    @Column(nullable = false, length = 1000)
+    private String message;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private NotificationSourceType sourceType;
+
+    @Column(nullable = false, length = 100)
+    private String sourceId;
+
+    @Column(nullable = false, unique = true, length = 180)
+    private String dedupeKey;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime readAt;
+
+    @PrePersist
+    void ensureDefaults() {
+        if (status == null) {
+            status = NotificationStatus.UNREAD;
+        }
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
+}

--- a/account-service/src/main/java/com/suhasan/finance/account_service/entity/NotificationSeverity.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/entity/NotificationSeverity.java
@@ -1,0 +1,8 @@
+package com.suhasan.finance.account_service.entity;
+
+public enum NotificationSeverity {
+    INFO,
+    SUCCESS,
+    WARNING,
+    CRITICAL
+}

--- a/account-service/src/main/java/com/suhasan/finance/account_service/entity/NotificationSourceType.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/entity/NotificationSourceType.java
@@ -1,0 +1,7 @@
+package com.suhasan.finance.account_service.entity;
+
+public enum NotificationSourceType {
+    ACCOUNT,
+    TRANSACTION,
+    DISPUTE
+}

--- a/account-service/src/main/java/com/suhasan/finance/account_service/entity/NotificationStatus.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/entity/NotificationStatus.java
@@ -1,0 +1,6 @@
+package com.suhasan.finance.account_service.entity;
+
+public enum NotificationStatus {
+    UNREAD,
+    READ
+}

--- a/account-service/src/main/java/com/suhasan/finance/account_service/entity/NotificationType.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/entity/NotificationType.java
@@ -1,0 +1,10 @@
+package com.suhasan.finance.account_service.entity;
+
+public enum NotificationType {
+    TRANSACTION_COMPLETED,
+    TRANSACTION_FAILED,
+    ACCOUNT_FROZEN,
+    ACCOUNT_UNFROZEN,
+    DISPUTE_CREATED,
+    DISPUTE_STATUS_UPDATED
+}

--- a/account-service/src/main/java/com/suhasan/finance/account_service/repository/NotificationRepository.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/repository/NotificationRepository.java
@@ -1,0 +1,30 @@
+package com.suhasan.finance.account_service.repository;
+
+import com.suhasan.finance.account_service.entity.Notification;
+import com.suhasan.finance.account_service.entity.NotificationSeverity;
+import com.suhasan.finance.account_service.entity.NotificationSourceType;
+import com.suhasan.finance.account_service.entity.NotificationStatus;
+import com.suhasan.finance.account_service.entity.NotificationType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long>, JpaSpecificationExecutor<Notification> {
+    Optional<Notification> findByDedupeKey(String dedupeKey);
+
+    Optional<Notification> findByNotificationIdAndUserId(Long notificationId, String userId);
+
+    long countByUserId(String userId);
+
+    long countByUserIdAndStatus(String userId, NotificationStatus status);
+
+    long countByUserIdAndSeverity(String userId, NotificationSeverity severity);
+
+    long countByUserIdAndType(String userId, NotificationType type);
+
+    List<Notification> findByUserIdAndStatus(String userId, NotificationStatus status);
+
+    long countByUserIdAndSourceType(String userId, NotificationSourceType sourceType);
+}

--- a/account-service/src/main/java/com/suhasan/finance/account_service/service/AccountService.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/service/AccountService.java
@@ -5,6 +5,7 @@ import com.suhasan.finance.account_service.dto.BalanceOperationRequest;
 import com.suhasan.finance.account_service.dto.BalanceOperationResponse;
 import com.suhasan.finance.account_service.dto.DebitHoldRequest;
 import com.suhasan.finance.account_service.dto.DebitHoldResponse;
+import com.suhasan.finance.account_service.dto.NotificationCreateRequest;
 import com.suhasan.finance.account_service.entity.Account;
 import com.suhasan.finance.account_service.entity.AccountBalanceOperation;
 import com.suhasan.finance.account_service.entity.AccountBalanceOperationId;
@@ -12,6 +13,9 @@ import com.suhasan.finance.account_service.entity.AccountDebitHold;
 import com.suhasan.finance.account_service.entity.AccountStatus;
 import com.suhasan.finance.account_service.entity.BalanceOperationStatus;
 import com.suhasan.finance.account_service.entity.DebitHoldStatus;
+import com.suhasan.finance.account_service.entity.NotificationSeverity;
+import com.suhasan.finance.account_service.entity.NotificationSourceType;
+import com.suhasan.finance.account_service.entity.NotificationType;
 import com.suhasan.finance.account_service.mapper.AccountMapper;
 import com.suhasan.finance.account_service.repository.AccountBalanceOperationRepository;
 import com.suhasan.finance.account_service.repository.AccountDebitHoldRepository;
@@ -22,8 +26,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -31,6 +37,7 @@ import java.util.List;
 
 @Service
 @Transactional
+@Slf4j
 public class AccountService {
 
     private final AccountRepository accountRepository;
@@ -38,6 +45,7 @@ public class AccountService {
     private final AccountDebitHoldRepository debitHoldRepository;
     private final AccountMapper accountMapper;
     private final MeterRegistry meterRegistry;
+    private NotificationService notificationService;
 
     private Counter createdCounter;
     private Timer creationTimer;
@@ -53,6 +61,11 @@ public class AccountService {
         this.accountMapper = accountMapper;
         this.meterRegistry = meterRegistry;
         initMetrics();
+    }
+
+    @Autowired
+    void setNotificationService(NotificationService notificationService) {
+        this.notificationService = notificationService;
     }
 
     private void initMetrics() {
@@ -103,7 +116,9 @@ public class AccountService {
         existing.setStatusReason(reason.trim());
         existing.setStatusUpdatedAt(LocalDateTime.now());
         existing.setStatusUpdatedBy(actor);
-        return accountRepository.save(existing);
+        Account saved = accountRepository.save(existing);
+        emitAccountStatusNotification(saved);
+        return saved;
     }
 
     public void delete(Long id) {
@@ -373,6 +388,40 @@ public class AccountService {
                 || !request.getTransactionId().equals(existing.getTransactionId())
                 || request.getAmount().compareTo(existing.getAmount()) != 0) {
             throw new IllegalArgumentException("Debit hold replay does not match original request: " + request.getHoldId());
+        }
+    }
+
+    private void emitAccountStatusNotification(Account account) {
+        if (notificationService == null || account.getStatus() == null) {
+            return;
+        }
+        NotificationType type;
+        NotificationSeverity severity;
+        String title;
+        if (account.getStatus() == AccountStatus.FROZEN) {
+            type = NotificationType.ACCOUNT_FROZEN;
+            severity = NotificationSeverity.CRITICAL;
+            title = "Account frozen";
+        } else if (account.getStatus() == AccountStatus.ACTIVE) {
+            type = NotificationType.ACCOUNT_UNFROZEN;
+            severity = NotificationSeverity.SUCCESS;
+            title = "Account unfrozen";
+        } else {
+            return;
+        }
+        try {
+            notificationService.createInternal(NotificationCreateRequest.builder()
+                    .userId(account.getOwnerId())
+                    .type(type)
+                    .severity(severity)
+                    .title(title)
+                    .message(account.getStatusReason())
+                    .sourceType(NotificationSourceType.ACCOUNT)
+                    .sourceId(String.valueOf(account.getId()))
+                    .dedupeKey("account-status:%s:%s:%s".formatted(account.getId(), account.getStatus(), account.getStatusUpdatedAt()))
+                    .build());
+        } catch (RuntimeException e) {
+            log.warn("Failed to create account status notification for account {}: {}", account.getId(), e.getMessage());
         }
     }
 }

--- a/account-service/src/main/java/com/suhasan/finance/account_service/service/NotificationService.java
+++ b/account-service/src/main/java/com/suhasan/finance/account_service/service/NotificationService.java
@@ -1,0 +1,150 @@
+package com.suhasan.finance.account_service.service;
+
+import com.suhasan.finance.account_service.dto.NotificationCreateRequest;
+import com.suhasan.finance.account_service.dto.NotificationFilter;
+import com.suhasan.finance.account_service.entity.Notification;
+import com.suhasan.finance.account_service.entity.NotificationSeverity;
+import com.suhasan.finance.account_service.entity.NotificationSourceType;
+import com.suhasan.finance.account_service.entity.NotificationStatus;
+import com.suhasan.finance.account_service.entity.NotificationType;
+import com.suhasan.finance.account_service.repository.NotificationRepository;
+import jakarta.persistence.criteria.Predicate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
+    public Notification createInternal(NotificationCreateRequest request) {
+        validateCreate(request);
+        return notificationRepository.findByDedupeKey(request.getDedupeKey().trim())
+                .orElseGet(() -> notificationRepository.save(Notification.builder()
+                        .userId(request.getUserId().trim())
+                        .type(request.getType())
+                        .severity(request.getSeverity())
+                        .status(NotificationStatus.UNREAD)
+                        .title(request.getTitle().trim())
+                        .message(request.getMessage().trim())
+                        .sourceType(request.getSourceType())
+                        .sourceId(request.getSourceId().trim())
+                        .dedupeKey(request.getDedupeKey().trim())
+                        .createdAt(LocalDateTime.now())
+                        .build()));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<Notification> listForUser(String userId, NotificationFilter filter, Pageable pageable) {
+        return notificationRepository.findAll(forUser(userId, filter), pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public Map<String, Object> summaryForUser(String userId) {
+        Map<String, Object> summary = new LinkedHashMap<>();
+        summary.put("total", notificationRepository.countByUserId(userId));
+        summary.put("unread", notificationRepository.countByUserIdAndStatus(userId, NotificationStatus.UNREAD));
+
+        Map<NotificationSeverity, Long> bySeverity = new EnumMap<>(NotificationSeverity.class);
+        for (NotificationSeverity severity : NotificationSeverity.values()) {
+            bySeverity.put(severity, notificationRepository.countByUserIdAndSeverity(userId, severity));
+        }
+        summary.put("bySeverity", bySeverity);
+
+        Map<NotificationType, Long> byType = new EnumMap<>(NotificationType.class);
+        for (NotificationType type : NotificationType.values()) {
+            byType.put(type, notificationRepository.countByUserIdAndType(userId, type));
+        }
+        summary.put("byType", byType);
+
+        Map<NotificationSourceType, Long> bySourceType = new EnumMap<>(NotificationSourceType.class);
+        for (NotificationSourceType sourceType : NotificationSourceType.values()) {
+            bySourceType.put(sourceType, notificationRepository.countByUserIdAndSourceType(userId, sourceType));
+        }
+        summary.put("bySourceType", bySourceType);
+        return summary;
+    }
+
+    @Transactional
+    public Notification markRead(Long notificationId, String userId) {
+        Notification notification = notificationRepository.findByNotificationIdAndUserId(notificationId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("Notification not found: " + notificationId));
+        if (notification.getStatus() != NotificationStatus.READ) {
+            notification.setStatus(NotificationStatus.READ);
+            notification.setReadAt(LocalDateTime.now());
+            return notificationRepository.save(notification);
+        }
+        return notification;
+    }
+
+    @Transactional
+    public int markAllRead(String userId) {
+        List<Notification> unread = notificationRepository.findByUserIdAndStatus(userId, NotificationStatus.UNREAD);
+        LocalDateTime readAt = LocalDateTime.now();
+        unread.forEach(notification -> {
+            notification.setStatus(NotificationStatus.READ);
+            notification.setReadAt(readAt);
+        });
+        notificationRepository.saveAll(unread);
+        return unread.size();
+    }
+
+    private Specification<Notification> forUser(String userId, NotificationFilter filter) {
+        return (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+            predicates.add(cb.equal(root.get("userId"), userId));
+            if (filter != null) {
+                if (filter.getStatus() != null) {
+                    predicates.add(cb.equal(root.get("status"), filter.getStatus()));
+                }
+                if (filter.getType() != null) {
+                    predicates.add(cb.equal(root.get("type"), filter.getType()));
+                }
+                if (filter.getSeverity() != null) {
+                    predicates.add(cb.equal(root.get("severity"), filter.getSeverity()));
+                }
+                if (filter.getSourceType() != null) {
+                    predicates.add(cb.equal(root.get("sourceType"), filter.getSourceType()));
+                }
+                if (filter.getFrom() != null) {
+                    predicates.add(cb.greaterThanOrEqualTo(root.get("createdAt"), filter.getFrom()));
+                }
+                if (filter.getTo() != null) {
+                    predicates.add(cb.lessThanOrEqualTo(root.get("createdAt"), filter.getTo()));
+                }
+            }
+            return cb.and(predicates.toArray(Predicate[]::new));
+        };
+    }
+
+    private void validateCreate(NotificationCreateRequest request) {
+        if (request == null
+                || !hasText(request.getUserId())
+                || request.getType() == null
+                || request.getSeverity() == null
+                || !hasText(request.getTitle())
+                || !hasText(request.getMessage())
+                || request.getSourceType() == null
+                || !hasText(request.getSourceId())
+                || !hasText(request.getDedupeKey())) {
+            throw new IllegalArgumentException("Notification user, type, severity, title, message, source, and dedupe key are required");
+        }
+    }
+
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/account-service/src/main/resources/db/migration/V5__create_notifications.sql
+++ b/account-service/src/main/resources/db/migration/V5__create_notifications.sql
@@ -1,0 +1,20 @@
+CREATE TABLE notifications (
+    notification_id BIGSERIAL PRIMARY KEY,
+    user_id VARCHAR(100) NOT NULL,
+    type VARCHAR(50) NOT NULL,
+    severity VARCHAR(20) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    title VARCHAR(160) NOT NULL,
+    message VARCHAR(1000) NOT NULL,
+    source_type VARCHAR(30) NOT NULL,
+    source_id VARCHAR(100) NOT NULL,
+    dedupe_key VARCHAR(180) NOT NULL UNIQUE,
+    created_at TIMESTAMP NOT NULL,
+    read_at TIMESTAMP
+);
+
+CREATE INDEX idx_notifications_user_id ON notifications(user_id);
+CREATE INDEX idx_notifications_status ON notifications(status);
+CREATE INDEX idx_notifications_type ON notifications(type);
+CREATE INDEX idx_notifications_source ON notifications(source_type, source_id);
+CREATE INDEX idx_notifications_created_at ON notifications(created_at);

--- a/account-service/src/test/java/com/suhasan/finance/account_service/controller/NotificationControllerTest.java
+++ b/account-service/src/test/java/com/suhasan/finance/account_service/controller/NotificationControllerTest.java
@@ -1,0 +1,118 @@
+package com.suhasan.finance.account_service.controller;
+
+import com.suhasan.finance.account_service.dto.NotificationCreateRequest;
+import com.suhasan.finance.account_service.entity.Notification;
+import com.suhasan.finance.account_service.entity.NotificationSeverity;
+import com.suhasan.finance.account_service.entity.NotificationSourceType;
+import com.suhasan.finance.account_service.entity.NotificationStatus;
+import com.suhasan.finance.account_service.entity.NotificationType;
+import com.suhasan.finance.account_service.service.NotificationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NotificationControllerTest {
+
+    private NotificationService notificationService;
+    private NotificationController controller;
+
+    @BeforeEach
+    void setUp() {
+        notificationService = mock(NotificationService.class);
+        controller = new NotificationController(notificationService);
+    }
+
+    @Test
+    @DisplayName("Customer lists only current user's notifications")
+    void customerListsOnlyCurrentUsersNotifications() {
+        Notification notification = Notification.builder()
+                .notificationId(1L)
+                .userId("customer")
+                .title("Transfer completed")
+                .build();
+        when(notificationService.listForUser(any(), any(), any())).thenReturn(new PageImpl<>(List.of(notification)));
+
+        var response = controller.list(null, null, null, null, null, null, PageRequest.of(0, 20), auth("customer", "ROLE_USER"));
+
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getContent()).containsExactly(notification);
+        verify(notificationService).listForUser(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("Customer marks own notification read")
+    void customerMarksOwnNotificationRead() {
+        Notification notification = Notification.builder()
+                .notificationId(7L)
+                .userId("customer")
+                .status(NotificationStatus.READ)
+                .build();
+        when(notificationService.markRead(7L, "customer")).thenReturn(notification);
+
+        var response = controller.markRead(7L, auth("customer", "ROLE_USER"));
+
+        assertThat(response.getBody()).isSameAs(notification);
+        verify(notificationService).markRead(7L, "customer");
+    }
+
+    @Test
+    @DisplayName("Admin can create internal notification for any user")
+    void adminCanCreateInternalNotificationForAnyUser() {
+        NotificationCreateRequest request = NotificationCreateRequest.builder()
+                .userId("customer")
+                .type(NotificationType.ACCOUNT_FROZEN)
+                .severity(NotificationSeverity.CRITICAL)
+                .title("Account frozen")
+                .message("Your account was frozen.")
+                .sourceType(NotificationSourceType.ACCOUNT)
+                .sourceId("1")
+                .dedupeKey("account-status:1:FROZEN:now")
+                .build();
+        Notification notification = Notification.builder().notificationId(11L).userId("customer").build();
+        when(notificationService.createInternal(request)).thenReturn(notification);
+
+        var response = controller.createInternal(request, auth("admin", "ROLE_ADMIN"));
+
+        assertThat(response.getStatusCode().value()).isEqualTo(201);
+        assertThat(response.getBody()).isSameAs(notification);
+    }
+
+    @Test
+    @DisplayName("Normal user cannot create internal notifications")
+    void normalUserCannotCreateInternalNotifications() {
+        assertThatThrownBy(() -> controller.createInternal(NotificationCreateRequest.builder().build(), auth("customer", "ROLE_USER")))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("Only admins or internal services can create notifications");
+    }
+
+    @Test
+    @DisplayName("Summary delegates to current user")
+    void summaryDelegatesToCurrentUser() {
+        when(notificationService.summaryForUser("customer")).thenReturn(Map.of("total", 2L, "unread", 1L));
+
+        var response = controller.summary(auth("customer", "ROLE_USER"));
+
+        assertThat(response.getBody()).containsEntry("total", 2L);
+        verify(notificationService).summaryForUser("customer");
+    }
+
+    private TestingAuthenticationToken auth(String name, String role) {
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(name, "token", role);
+        authentication.setAuthenticated(true);
+        return authentication;
+    }
+}

--- a/account-service/src/test/java/com/suhasan/finance/account_service/service/NotificationServiceTest.java
+++ b/account-service/src/test/java/com/suhasan/finance/account_service/service/NotificationServiceTest.java
@@ -1,0 +1,126 @@
+package com.suhasan.finance.account_service.service;
+
+import com.suhasan.finance.account_service.dto.NotificationCreateRequest;
+import com.suhasan.finance.account_service.entity.Notification;
+import com.suhasan.finance.account_service.entity.NotificationSeverity;
+import com.suhasan.finance.account_service.entity.NotificationSourceType;
+import com.suhasan.finance.account_service.entity.NotificationStatus;
+import com.suhasan.finance.account_service.entity.NotificationType;
+import com.suhasan.finance.account_service.repository.NotificationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    private NotificationService notificationService;
+
+    @BeforeEach
+    void setUp() {
+        notificationService = new NotificationService(notificationRepository);
+    }
+
+    @Test
+    @DisplayName("Creates unread notification with trimmed title and message")
+    void createsUnreadNotificationWithTrimmedTitleAndMessage() {
+        when(notificationRepository.findByDedupeKey("transaction:tx-1:COMPLETED")).thenReturn(Optional.empty());
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Notification created = notificationService.createInternal(NotificationCreateRequest.builder()
+                .userId("customer")
+                .type(NotificationType.TRANSACTION_COMPLETED)
+                .severity(NotificationSeverity.SUCCESS)
+                .title("  Transfer completed  ")
+                .message("  Your transfer was completed.  ")
+                .sourceType(NotificationSourceType.TRANSACTION)
+                .sourceId("tx-1")
+                .dedupeKey("transaction:tx-1:COMPLETED")
+                .build());
+
+        assertThat(created.getStatus()).isEqualTo(NotificationStatus.UNREAD);
+        assertThat(created.getTitle()).isEqualTo("Transfer completed");
+        assertThat(created.getMessage()).isEqualTo("Your transfer was completed.");
+        assertThat(created.getCreatedAt()).isNotNull();
+        verify(notificationRepository).save(created);
+    }
+
+    @Test
+    @DisplayName("Returns existing notification for duplicate dedupe key")
+    void returnsExistingNotificationForDuplicateDedupeKey() {
+        Notification existing = Notification.builder()
+                .notificationId(10L)
+                .userId("customer")
+                .dedupeKey("dispute:dp-1:created")
+                .createdAt(LocalDateTime.now())
+                .build();
+        when(notificationRepository.findByDedupeKey("dispute:dp-1:created")).thenReturn(Optional.of(existing));
+
+        Notification result = notificationService.createInternal(NotificationCreateRequest.builder()
+                .userId("customer")
+                .type(NotificationType.DISPUTE_CREATED)
+                .severity(NotificationSeverity.INFO)
+                .title("Dispute opened")
+                .message("We opened your dispute.")
+                .sourceType(NotificationSourceType.DISPUTE)
+                .sourceId("dp-1")
+                .dedupeKey("dispute:dp-1:created")
+                .build());
+
+        assertThat(result).isSameAs(existing);
+        verify(notificationRepository, never()).save(any(Notification.class));
+    }
+
+    @Test
+    @DisplayName("Rejects missing required create fields")
+    void rejectsMissingRequiredCreateFields() {
+        assertThatThrownBy(() -> notificationService.createInternal(NotificationCreateRequest.builder()
+                .userId("customer")
+                .severity(NotificationSeverity.INFO)
+                .title(" ")
+                .message("Message")
+                .sourceType(NotificationSourceType.ACCOUNT)
+                .sourceId("1")
+                .dedupeKey("account:1")
+                .build()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Notification user, type, severity, title, message, source, and dedupe key are required");
+    }
+
+    @Test
+    @DisplayName("Marks only owned unread notification as read")
+    void marksOnlyOwnedUnreadNotificationAsRead() {
+        Notification notification = Notification.builder()
+                .notificationId(5L)
+                .userId("customer")
+                .status(NotificationStatus.UNREAD)
+                .build();
+        when(notificationRepository.findByNotificationIdAndUserId(5L, "customer")).thenReturn(Optional.of(notification));
+        when(notificationRepository.save(any(Notification.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Notification result = notificationService.markRead(5L, "customer");
+
+        assertThat(result.getStatus()).isEqualTo(NotificationStatus.READ);
+        assertThat(result.getReadAt()).isNotNull();
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertThat(captor.getValue().getNotificationId()).isEqualTo(5L);
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { DisputesPage } from "./pages/DisputesPage";
 import { DashboardPage } from "./pages/DashboardPage";
 import { LoginPage } from "./pages/LoginPage";
 import { MoveMoneyPage } from "./pages/MoveMoneyPage";
+import { NotificationsPage } from "./pages/NotificationsPage";
 import { RegisterPage } from "./pages/RegisterPage";
 import { TransactionsPage } from "./pages/TransactionsPage";
 
@@ -31,6 +32,7 @@ export function App() {
           <Route path="move-money" element={<MoveMoneyPage />} />
           <Route path="transactions" element={<TransactionsPage />} />
           <Route path="disputes" element={<DisputesPage />} />
+          <Route path="notifications" element={<NotificationsPage />} />
         </Route>
         <Route element={<RequireAuth admin />}>
           <Route path="admin" element={<AdminLayout />}>

--- a/frontend/src/components/CustomerLayout.tsx
+++ b/frontend/src/components/CustomerLayout.tsx
@@ -1,18 +1,21 @@
 import { Link, NavLink, Outlet } from "react-router-dom";
-import { ArrowLeftRight, Banknote, CircleHelp, Gauge, Landmark, LogOut, WalletCards } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowLeftRight, Banknote, Bell, CircleHelp, Gauge, Landmark, LogOut, WalletCards } from "lucide-react";
 import clsx from "clsx";
 import { Button } from "./ui";
 import { useAuth } from "../state/useAuth";
+import { getNotificationSummary } from "../lib/queries";
 
 const navItems = [
   { to: "/", label: "Dashboard", icon: Gauge },
   { to: "/accounts", label: "Accounts", icon: WalletCards },
   { to: "/move-money", label: "Move Money", icon: ArrowLeftRight },
   { to: "/transactions", label: "Transactions", icon: Banknote },
-  { to: "/disputes", label: "Disputes", icon: CircleHelp }
+  { to: "/disputes", label: "Disputes", icon: CircleHelp },
+  { to: "/notifications", label: "Notifications", icon: Bell }
 ];
 
-function NavigationLink({ to, label, icon: Icon }: { to: string; label: string; icon: React.ComponentType<{ className?: string }> }) {
+function NavigationLink({ to, label, icon: Icon, badge }: { to: string; label: string; icon: React.ComponentType<{ className?: string }>; badge?: number }) {
   return (
     <NavLink
       to={to}
@@ -25,12 +28,15 @@ function NavigationLink({ to, label, icon: Icon }: { to: string; label: string; 
     >
       <Icon className="h-4 w-4" />
       <span>{label}</span>
+      {badge ? <span aria-hidden="true" className="ml-auto rounded-full bg-danger px-2 py-0.5 text-xs font-semibold text-white">{badge}</span> : null}
     </NavLink>
   );
 }
 
 export function CustomerLayout() {
   const { session, logout } = useAuth();
+  const summary = useQuery({ queryKey: ["notification-summary"], queryFn: getNotificationSummary });
+  const unread = summary.data?.unread ?? 0;
 
   return (
     <div className="min-h-screen bg-slate-100 text-ink">
@@ -41,7 +47,7 @@ export function CustomerLayout() {
         </Link>
         <nav className="mt-6 grid gap-1">
           {navItems.map((item) => (
-            <NavigationLink key={item.to} {...item} />
+            <NavigationLink key={item.to} {...item} badge={item.to === "/notifications" ? unread : undefined} />
           ))}
         </nav>
       </aside>

--- a/frontend/src/lib/queries.ts
+++ b/frontend/src/lib/queries.ts
@@ -1,4 +1,4 @@
-import type { Account, AccountStatus, AuditLogEntry, AuditSummary, DisputeSummary, InvestigationSummary, InvestigationTimelineItem, Limits, Page, RiskAlert, RiskCase, RiskCaseSummary, RiskSummary, Transaction, TransactionDispute, TransactionStats } from "../types";
+import type { Account, AccountStatus, AuditLogEntry, AuditSummary, DisputeSummary, InvestigationSummary, InvestigationTimelineItem, Limits, Notification, NotificationSeverity, NotificationSourceType, NotificationStatus, NotificationSummary, NotificationType, Page, RiskAlert, RiskCase, RiskCaseSummary, RiskSummary, Transaction, TransactionDispute, TransactionStats } from "../types";
 import { apiRequest, toQuery } from "./api";
 import type { AccountValues, DisputeNoteValues, DisputeStatusValues, DisputeValues, LoginValues, MoneyMovementValues, RegisterValues, ReversalValues, TransferValues } from "./schemas";
 import { getSession } from "./session";
@@ -42,6 +42,29 @@ export function deleteAccount(id: number) {
 
 export function updateAccountStatus(id: number, values: { status: AccountStatus; reason: string }) {
   return apiRequest<Account>("account", `/api/accounts/${id}/status`, { method: "PATCH", body: values });
+}
+
+export function listNotifications(params: {
+  status?: NotificationStatus | "";
+  type?: NotificationType | "";
+  severity?: NotificationSeverity | "";
+  sourceType?: NotificationSourceType | "";
+  page?: number;
+  size?: number;
+} = {}) {
+  return apiRequest<Page<Notification>>("account", `/api/notifications${toQuery({ page: 0, size: 20, sort: "createdAt,desc", ...params })}`);
+}
+
+export function getNotificationSummary() {
+  return apiRequest<NotificationSummary>("account", "/api/notifications/summary");
+}
+
+export function markNotificationRead(notificationId: number) {
+  return apiRequest<Notification>("account", `/api/notifications/${notificationId}/read`, { method: "PATCH" });
+}
+
+export function markAllNotificationsRead() {
+  return apiRequest<{ updated: number }>("account", "/api/notifications/read-all", { method: "PATCH" });
 }
 
 export function getTransactions(page = 0) {

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -1,0 +1,122 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
+import { useState } from "react";
+import { Bell, Check, CheckCheck } from "lucide-react";
+import { Badge, Button, EmptyState, Field, Panel, Select } from "../components/ui";
+import { getNotificationSummary, listNotifications, markAllNotificationsRead, markNotificationRead } from "../lib/queries";
+import type { Notification, NotificationSeverity, NotificationStatus, NotificationType } from "../types";
+
+const notificationTypes: Array<NotificationType | ""> = ["", "TRANSACTION_COMPLETED", "TRANSACTION_FAILED", "ACCOUNT_FROZEN", "ACCOUNT_UNFROZEN", "DISPUTE_CREATED", "DISPUTE_STATUS_UPDATED"];
+const severities: Array<NotificationSeverity | ""> = ["", "INFO", "SUCCESS", "WARNING", "CRITICAL"];
+const statuses: Array<NotificationStatus | ""> = ["", "UNREAD", "READ"];
+
+export function NotificationsPage() {
+  const [status, setStatus] = useState<NotificationStatus | "">("");
+  const [type, setType] = useState<NotificationType | "">("");
+  const [severity, setSeverity] = useState<NotificationSeverity | "">("");
+  const queryClient = useQueryClient();
+  const notifications = useQuery({ queryKey: ["notifications", status, type, severity], queryFn: () => listNotifications({ status, type, severity }) });
+  const summary = useQuery({ queryKey: ["notification-summary"], queryFn: getNotificationSummary });
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    queryClient.invalidateQueries({ queryKey: ["notification-summary"] });
+  };
+  const markRead = useMutation({ mutationFn: markNotificationRead, onSuccess: invalidate });
+  const markAllRead = useMutation({ mutationFn: markAllNotificationsRead, onSuccess: invalidate });
+  const unread = summary.data?.unread ?? 0;
+
+  return (
+    <div className="grid gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold">Notifications</h1>
+          <p className="text-sm text-muted">{unread} unread</p>
+        </div>
+        <Button variant="secondary" onClick={() => markAllRead.mutate()} disabled={!unread || markAllRead.isPending}>
+          <CheckCheck className="h-4 w-4" />
+          Mark all read
+        </Button>
+      </div>
+
+      <Panel>
+        <div className="grid gap-3 md:grid-cols-3">
+          <Field label="Status">
+            <Select value={status} onChange={(event) => setStatus(event.target.value as NotificationStatus | "")}>
+              {statuses.map((value) => <option key={value || "all"} value={value}>{value || "All statuses"}</option>)}
+            </Select>
+          </Field>
+          <Field label="Type">
+            <Select value={type} onChange={(event) => setType(event.target.value as NotificationType | "")}>
+              {notificationTypes.map((value) => <option key={value || "all"} value={value}>{value || "All types"}</option>)}
+            </Select>
+          </Field>
+          <Field label="Severity">
+            <Select value={severity} onChange={(event) => setSeverity(event.target.value as NotificationSeverity | "")}>
+              {severities.map((value) => <option key={value || "all"} value={value}>{value || "All severities"}</option>)}
+            </Select>
+          </Field>
+        </div>
+      </Panel>
+
+      <Panel title="Inbox">
+        {notifications.error instanceof Error ? <p className="text-sm text-danger">{notifications.error.message}</p> : null}
+        {notifications.isLoading ? <p className="text-sm text-muted">Loading notifications...</p> : null}
+        {!notifications.isLoading && !notifications.data?.content.length ? <EmptyState title="No notifications found" detail="Adjust filters to review another inbox segment." /> : null}
+        {notifications.data?.content.length ? <NotificationList notifications={notifications.data.content} onMarkRead={(id) => markRead.mutate(id)} markingId={markRead.variables} /> : null}
+      </Panel>
+    </div>
+  );
+}
+
+function NotificationList({ notifications, onMarkRead, markingId }: { notifications: Notification[]; onMarkRead: (id: number) => void; markingId?: number }) {
+  return (
+    <div className="grid gap-3">
+      {notifications.map((notification) => (
+        <article key={notification.notificationId} className="rounded-md border border-line bg-white p-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <Bell className="h-4 w-4 text-brand" />
+                <h3 className="text-sm font-semibold text-ink">{notification.title}</h3>
+                <Badge tone={severityTone(notification.severity)}>{notification.severity}</Badge>
+                <Badge tone={notification.status === "UNREAD" ? "info" : "neutral"}>{notification.status}</Badge>
+              </div>
+              <p className="mt-2 text-sm text-muted">{notification.message}</p>
+              <div className="mt-3 flex flex-wrap gap-3 text-xs text-muted">
+                <span>{notification.type}</span>
+                <SourceLink notification={notification} />
+                <span>{new Date(notification.createdAt).toLocaleString()}</span>
+              </div>
+            </div>
+            {notification.status === "UNREAD" ? (
+              <Button variant="secondary" onClick={() => onMarkRead(notification.notificationId)} disabled={markingId === notification.notificationId}>
+                <Check className="h-4 w-4" />
+                Mark read
+              </Button>
+            ) : null}
+          </div>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function SourceLink({ notification }: { notification: Notification }) {
+  if (notification.sourceType === "TRANSACTION") {
+    return <Link className="font-medium text-brand hover:underline" to={`/transactions?transactionId=${notification.sourceId}`}>TRANSACTION {notification.sourceId}</Link>;
+  }
+  if (notification.sourceType === "DISPUTE") {
+    return <Link className="font-medium text-brand hover:underline" to="/disputes">DISPUTE {notification.sourceId}</Link>;
+  }
+  if (notification.sourceType === "ACCOUNT") {
+    return <Link className="font-medium text-brand hover:underline" to="/accounts">ACCOUNT {notification.sourceId}</Link>;
+  }
+  return <span>{notification.sourceType} {notification.sourceId}</span>;
+}
+
+function severityTone(severity: NotificationSeverity) {
+  if (severity === "SUCCESS") return "good";
+  if (severity === "WARNING") return "warn";
+  if (severity === "CRITICAL") return "bad";
+  return "info";
+}

--- a/frontend/src/test/app.component.test.tsx
+++ b/frontend/src/test/app.component.test.tsx
@@ -83,6 +83,12 @@ function mockFetch(handler?: (url: string, init?: RequestInit) => Promise<Respon
     if (url.includes("/api/accounts")) {
       return jsonResponse({ ...emptyPage, content: [sampleAccount], totalElements: 1, totalPages: 1 });
     }
+    if (url.includes("/api/notifications/summary")) {
+      return jsonResponse({ total: 0, unread: 0, bySeverity: {}, byType: {}, bySourceType: {} });
+    }
+    if (url.includes("/api/notifications")) {
+      return jsonResponse(emptyPage);
+    }
     if (url.includes("/api/transactions/user/stats")) {
       return jsonResponse({ totalTransactions: 0, successRate: 0, transactionCountsByType: {} });
     }
@@ -335,6 +341,7 @@ describe("customer shell navigation", () => {
     expect(screen.getByRole("link", { name: "Move Money" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Transactions" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Disputes" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Notifications" })).toBeInTheDocument();
     expect(screen.queryByText("Operations")).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Admin Accounts" })).not.toBeInTheDocument();
     unmount();
@@ -346,6 +353,7 @@ describe("customer shell navigation", () => {
     expect(screen.getByRole("link", { name: "Move Money" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Transactions" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Disputes" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Notifications" })).toBeInTheDocument();
     expect(screen.queryByText("Operations")).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Admin Accounts" })).not.toBeInTheDocument();
   });
@@ -382,6 +390,61 @@ describe("customer shell navigation", () => {
 
     expect(await screen.findByRole("heading", { name: "Dashboard" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Monitoring" })).not.toBeInTheDocument();
+  });
+});
+
+describe("customer notifications", () => {
+  it("shows unread badge and marks notifications read", async () => {
+    const user = userEvent.setup();
+    const { calls } = mockFetch((url, init) => {
+      if (url.includes("/api/notifications/summary")) {
+        return jsonResponse({ total: 2, unread: 1, bySeverity: { SUCCESS: 1 }, byType: { TRANSACTION_COMPLETED: 1 }, bySourceType: { TRANSACTION: 1 } });
+      }
+      if (url.includes("/api/notifications/1/read") && init?.method === "PATCH") {
+        return jsonResponse({ notificationId: 1, status: "READ" });
+      }
+      if (url.includes("/api/notifications/read-all") && init?.method === "PATCH") {
+        return jsonResponse({ updated: 1 });
+      }
+      if (url.includes("/api/notifications")) {
+        return jsonResponse({
+          ...emptyPage,
+          content: [
+            {
+              notificationId: 1,
+              userId: "customer",
+              type: "TRANSACTION_COMPLETED",
+              severity: "SUCCESS",
+              status: "UNREAD",
+              title: "Transaction completed",
+              message: "TRANSFER completed for USD 100.00.",
+              sourceType: "TRANSACTION",
+              sourceId: "txn-1",
+              dedupeKey: "transaction:txn-1:COMPLETED",
+              createdAt: "2026-05-30T10:00:00Z"
+            }
+          ],
+          totalElements: 1,
+          totalPages: 1
+        });
+      }
+      return undefined;
+    });
+
+    renderApp("/notifications", tokenFor({ sub: "customer", roles: ["ROLE_USER"] }));
+
+    expect(await screen.findByRole("heading", { name: "Notifications" })).toBeInTheDocument();
+    expect(await screen.findByText("Transaction completed")).toBeInTheDocument();
+    expect(screen.getByText("1 unread")).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText("Status"), "UNREAD");
+    await user.selectOptions(screen.getByLabelText("Type"), "TRANSACTION_COMPLETED");
+    expect(calls.some(({ url }) => url.includes("/account-api/api/notifications") && url.includes("status=UNREAD") && url.includes("type=TRANSACTION_COMPLETED"))).toBe(true);
+
+    await user.click(screen.getByRole("button", { name: "Mark read" }));
+    await waitFor(() => expect(calls.some(({ url, init }) => url.includes("/account-api/api/notifications/1/read") && init?.method === "PATCH")).toBe(true));
+
+    await user.click(screen.getByRole("button", { name: "Mark all read" }));
+    await waitFor(() => expect(calls.some(({ url, init }) => url.includes("/account-api/api/notifications/read-all") && init?.method === "PATCH")).toBe(true));
   });
 });
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -30,6 +30,34 @@ export type Account = {
   dueDate?: string;
 };
 
+export type NotificationType = "TRANSACTION_COMPLETED" | "TRANSACTION_FAILED" | "ACCOUNT_FROZEN" | "ACCOUNT_UNFROZEN" | "DISPUTE_CREATED" | "DISPUTE_STATUS_UPDATED";
+export type NotificationSeverity = "INFO" | "SUCCESS" | "WARNING" | "CRITICAL";
+export type NotificationStatus = "UNREAD" | "READ";
+export type NotificationSourceType = "ACCOUNT" | "TRANSACTION" | "DISPUTE";
+
+export type Notification = {
+  notificationId: number;
+  userId: string;
+  type: NotificationType;
+  severity: NotificationSeverity;
+  status: NotificationStatus;
+  title: string;
+  message: string;
+  sourceType: NotificationSourceType;
+  sourceId: string;
+  dedupeKey: string;
+  createdAt: string;
+  readAt?: string;
+};
+
+export type NotificationSummary = {
+  total: number;
+  unread: number;
+  bySeverity: Partial<Record<NotificationSeverity, number>>;
+  byType: Partial<Record<NotificationType, number>>;
+  bySourceType: Partial<Record<NotificationSourceType, number>>;
+};
+
 export type TransactionType = "DEPOSIT" | "WITHDRAWAL" | "TRANSFER" | "REVERSAL" | string;
 export type TransactionStatus = "COMPLETED" | "PENDING" | "FAILED" | "REVERSED" | string;
 export type DisputeStatus = "OPEN" | "IN_REVIEW" | "APPROVED" | "DENIED" | "CLOSED";

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/client/ResilientAccountServiceClient.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/client/ResilientAccountServiceClient.java
@@ -11,6 +11,7 @@ import io.github.resilience4j.timelimiter.TimeLimiter;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -298,6 +299,24 @@ public class ResilientAccountServiceClient {
         }
     }
 
+    public void createNotification(NotificationRequest request) {
+        String serviceToken = generateInternalServiceToken();
+        try {
+            WebClient webClient = webClientBuilder.baseUrl(accountServiceBaseUrl).build();
+            webClient.post()
+                    .uri("/api/internal/notifications")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + serviceToken)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(Void.class)
+                    .timeout(Duration.ofMillis(timeout))
+                    .block();
+        } catch (Exception e) {
+            throw mapServiceException("notification creation", e);
+        }
+    }
+
     private Mono<Boolean> checkHealthAsync() {
         WebClient webClient = webClientBuilder.baseUrl(accountServiceBaseUrl).build();
         return webClient.get()
@@ -416,6 +435,21 @@ public class ResilientAccountServiceClient {
     public static class HoldTransitionRequest {
         private String transactionId;
         private String reason;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NotificationRequest {
+        private String userId;
+        private String type;
+        private String severity;
+        private String title;
+        private String message;
+        private String sourceType;
+        private String sourceId;
+        private String dedupeKey;
     }
 
     @Data

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/service/TransactionDisputeService.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/service/TransactionDisputeService.java
@@ -1,5 +1,6 @@
 package com.suhasan.finance.transaction_service.service;
 
+import com.suhasan.finance.transaction_service.client.ResilientAccountServiceClient;
 import com.suhasan.finance.transaction_service.dto.DisputeCreateRequest;
 import com.suhasan.finance.transaction_service.dto.DisputeFilter;
 import com.suhasan.finance.transaction_service.dto.DisputeNoteRequest;
@@ -16,6 +17,7 @@ import com.suhasan.finance.transaction_service.repository.TransactionDisputeRepo
 import com.suhasan.finance.transaction_service.repository.TransactionRepository;
 import jakarta.persistence.criteria.Predicate;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -30,6 +32,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class TransactionDisputeService {
 
     private static final DateTimeFormatter DISPUTE_DAY = DateTimeFormatter.BASIC_ISO_DATE;
@@ -39,6 +42,7 @@ public class TransactionDisputeService {
     private final TransactionDisputeNoteRepository noteRepository;
     private final TransactionRepository transactionRepository;
     private final AuditService auditService;
+    private final ResilientAccountServiceClient accountServiceClient;
 
     @Transactional
     public TransactionDisputeResponse createDispute(DisputeCreateRequest request, String userId) {
@@ -70,6 +74,7 @@ public class TransactionDisputeService {
                 .build();
         TransactionDispute saved = disputeRepository.save(dispute);
         auditService.logDisputeEvent("DISPUTE_CREATED", saved.getDisputeId(), saved.getTransactionId(), userId, saved.getDescription());
+        emitDisputeCreatedNotification(saved);
         return toResponse(saved);
     }
 
@@ -144,6 +149,7 @@ public class TransactionDisputeService {
         }
         TransactionDispute saved = disputeRepository.save(dispute);
         auditService.logDisputeEvent("DISPUTE_STATUS_UPDATED", saved.getDisputeId(), saved.getTransactionId(), admin, request.getStatus().name());
+        emitDisputeStatusNotification(saved);
         return toResponse(saved);
     }
 
@@ -246,5 +252,47 @@ public class TransactionDisputeService {
 
     private String trimOrNull(String value) {
         return hasText(value) ? value.trim() : null;
+    }
+
+    private void emitDisputeCreatedNotification(TransactionDispute dispute) {
+        try {
+            accountServiceClient.createNotification(ResilientAccountServiceClient.NotificationRequest.builder()
+                    .userId(dispute.getUserId())
+                    .type("DISPUTE_CREATED")
+                    .severity("INFO")
+                    .title("Dispute submitted")
+                    .message("Your dispute %s has been submitted for review.".formatted(dispute.getDisputeNumber()))
+                    .sourceType("DISPUTE")
+                    .sourceId(dispute.getDisputeId())
+                    .dedupeKey("dispute:%s:created".formatted(dispute.getDisputeId()))
+                    .build());
+        } catch (RuntimeException e) {
+            log.warn("Failed to create dispute notification for dispute {}: {}", dispute.getDisputeId(), e.getMessage());
+        }
+    }
+
+    private void emitDisputeStatusNotification(TransactionDispute dispute) {
+        if (dispute.getStatus() != DisputeStatus.APPROVED
+                && dispute.getStatus() != DisputeStatus.DENIED
+                && dispute.getStatus() != DisputeStatus.CLOSED) {
+            return;
+        }
+        try {
+            accountServiceClient.createNotification(ResilientAccountServiceClient.NotificationRequest.builder()
+                    .userId(dispute.getUserId())
+                    .type("DISPUTE_STATUS_UPDATED")
+                    .severity(dispute.getStatus() == DisputeStatus.APPROVED ? "SUCCESS" : "WARNING")
+                    .title("Dispute status updated")
+                    .message("Your dispute %s is now %s.%s".formatted(
+                            dispute.getDisputeNumber(),
+                            dispute.getStatus(),
+                            hasText(dispute.getResolutionNote()) ? " " + dispute.getResolutionNote() : ""))
+                    .sourceType("DISPUTE")
+                    .sourceId(dispute.getDisputeId())
+                    .dedupeKey("dispute:%s:status:%s".formatted(dispute.getDisputeId(), dispute.getStatus()))
+                    .build());
+        } catch (RuntimeException e) {
+            log.warn("Failed to create dispute status notification for dispute {}: {}", dispute.getDisputeId(), e.getMessage());
+        }
     }
 }

--- a/transaction-service/src/main/java/com/suhasan/finance/transaction_service/service/TransactionServiceImpl.java
+++ b/transaction-service/src/main/java/com/suhasan/finance/transaction_service/service/TransactionServiceImpl.java
@@ -176,6 +176,7 @@ public class TransactionServiceImpl implements TransactionService {
             riskEvaluationService.evaluateCompletedTransaction(transaction);
             metricsService.recordTransactionCompleted(TransactionType.TRANSFER,
                     TransactionStatus.COMPLETED, request.getAmount(), processingTime);
+            emitTransactionNotification(transaction);
             return mapToResponse(transaction);
         } catch (Exception e) {
             if (holdCaptured) {
@@ -211,6 +212,7 @@ public class TransactionServiceImpl implements TransactionService {
                     userId, e.getMessage(), "PROCESSING_ERROR");
             riskEvaluationService.evaluateFailedTransaction(transaction);
             metricsService.recordTransactionFailed(TransactionType.TRANSFER, "PROCESSING_ERROR");
+            emitTransactionNotification(transaction);
             throw new RuntimeException("Transfer failed: " + e.getMessage());
         }
     }
@@ -278,12 +280,14 @@ public class TransactionServiceImpl implements TransactionService {
             transaction.setProcessingState(TransactionProcessingState.COMPLETED);
             transaction = transactionRepository.save(transaction);
             riskEvaluationService.evaluateCompletedTransaction(transaction);
+            emitTransactionNotification(transaction);
             return mapToResponse(transaction);
         } catch (Exception e) {
             transaction.setStatus(TransactionStatus.FAILED);
             transaction.setProcessedAt(LocalDateTime.now());
             transactionRepository.save(transaction);
             riskEvaluationService.evaluateFailedTransaction(transaction);
+            emitTransactionNotification(transaction);
             throw new RuntimeException("Deposit failed: " + e.getMessage());
         }
     }
@@ -380,6 +384,7 @@ public class TransactionServiceImpl implements TransactionService {
             transaction.setProcessingState(TransactionProcessingState.COMPLETED);
             transaction = transactionRepository.save(transaction);
             riskEvaluationService.evaluateCompletedTransaction(transaction);
+            emitTransactionNotification(transaction);
             return mapToResponse(transaction);
         } catch (Exception e) {
             if (holdPlaced && !holdCaptured) {
@@ -390,6 +395,7 @@ public class TransactionServiceImpl implements TransactionService {
                 transaction.setProcessedAt(LocalDateTime.now());
                 transactionRepository.save(transaction);
                 riskEvaluationService.evaluateFailedTransaction(transaction);
+                emitTransactionNotification(transaction);
             }
             throw new RuntimeException("Withdrawal failed: " + e.getMessage());
         }
@@ -1024,6 +1030,39 @@ public class TransactionServiceImpl implements TransactionService {
 
     private boolean isExternalAccount(String accountId) {
         return accountId != null && "EXTERNAL".equalsIgnoreCase(accountId.trim());
+    }
+
+    private void emitTransactionNotification(Transaction transaction) {
+        if (transaction == null
+                || transaction.getStatus() == null
+                || (transaction.getStatus() != TransactionStatus.COMPLETED && transaction.getStatus() != TransactionStatus.FAILED)) {
+            return;
+        }
+        try {
+            boolean completed = transaction.getStatus() == TransactionStatus.COMPLETED;
+            accountServiceClient.createNotification(ResilientAccountServiceClient.NotificationRequest.builder()
+                    .userId(transaction.getCreatedBy())
+                    .type(completed ? "TRANSACTION_COMPLETED" : "TRANSACTION_FAILED")
+                    .severity(completed ? "SUCCESS" : "WARNING")
+                    .title(completed ? "Transaction completed" : "Transaction failed")
+                    .message(transactionMessage(transaction, completed))
+                    .sourceType("TRANSACTION")
+                    .sourceId(transaction.getTransactionId())
+                    .dedupeKey("transaction:%s:%s".formatted(transaction.getTransactionId(), transaction.getStatus()))
+                    .build());
+        } catch (RuntimeException e) {
+            log.warn("Failed to create transaction notification for transaction {}: {}",
+                    transaction.getTransactionId(), e.getMessage());
+        }
+    }
+
+    private String transactionMessage(Transaction transaction, boolean completed) {
+        String status = completed ? "completed" : "failed";
+        return "%s %s for %s %s.".formatted(
+                transaction.getType(),
+                status,
+                transaction.getCurrency(),
+                transaction.getAmount());
     }
 
     private TransactionResponse mapToResponse(Transaction transaction) {

--- a/transaction-service/src/test/java/com/suhasan/finance/transaction_service/service/TransactionDisputeServiceTest.java
+++ b/transaction-service/src/test/java/com/suhasan/finance/transaction_service/service/TransactionDisputeServiceTest.java
@@ -1,5 +1,6 @@
 package com.suhasan.finance.transaction_service.service;
 
+import com.suhasan.finance.transaction_service.client.ResilientAccountServiceClient;
 import com.suhasan.finance.transaction_service.dto.DisputeCreateRequest;
 import com.suhasan.finance.transaction_service.dto.DisputeNoteRequest;
 import com.suhasan.finance.transaction_service.dto.DisputeStatusUpdateRequest;
@@ -31,6 +32,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -49,11 +51,14 @@ class TransactionDisputeServiceTest {
     @Mock
     private AuditService auditService;
 
+    @Mock
+    private ResilientAccountServiceClient accountServiceClient;
+
     private TransactionDisputeService disputeService;
 
     @BeforeEach
     void setUp() {
-        disputeService = new TransactionDisputeService(disputeRepository, noteRepository, transactionRepository, auditService);
+        disputeService = new TransactionDisputeService(disputeRepository, noteRepository, transactionRepository, auditService, accountServiceClient);
     }
 
     @Test
@@ -73,6 +78,25 @@ class TransactionDisputeServiceTest {
         assertThat(result.getStatus()).isEqualTo(DisputeStatus.OPEN);
         assertThat(result.getReasonCode()).isEqualTo(DisputeReasonCode.UNAUTHORIZED);
         assertThat(result.getDisputeNumber()).startsWith("DP-");
+        verify(auditService).logDisputeEvent("DISPUTE_CREATED", result.getDisputeId(), "txn-1", "customer", "I did not authorize this transaction.");
+        verify(accountServiceClient).createNotification(any(ResilientAccountServiceClient.NotificationRequest.class));
+    }
+
+    @Test
+    void createDispute_DoesNotFailWhenNotificationEmissionFails() {
+        Transaction transaction = transaction("txn-1", "customer", TransactionStatus.COMPLETED, LocalDateTime.now().minusDays(5));
+        when(transactionRepository.findById("txn-1")).thenReturn(Optional.of(transaction));
+        when(disputeRepository.existsActiveByTransactionId("txn-1")).thenReturn(false);
+        when(disputeRepository.countByCreatedAtBetween(any(), any())).thenReturn(0L);
+        when(disputeRepository.save(any(TransactionDispute.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        doThrow(new RuntimeException("account service down"))
+                .when(accountServiceClient).createNotification(any(ResilientAccountServiceClient.NotificationRequest.class));
+
+        TransactionDisputeResponse result = disputeService.createDispute(
+                new DisputeCreateRequest("txn-1", DisputeReasonCode.UNAUTHORIZED, "I did not authorize this transaction."),
+                "customer");
+
+        assertThat(result.getStatus()).isEqualTo(DisputeStatus.OPEN);
         verify(auditService).logDisputeEvent("DISPUTE_CREATED", result.getDisputeId(), "txn-1", "customer", "I did not authorize this transaction.");
     }
 

--- a/transaction-service/src/test/java/com/suhasan/finance/transaction_service/service/TransactionServiceImplTest.java
+++ b/transaction-service/src/test/java/com/suhasan/finance/transaction_service/service/TransactionServiceImplTest.java
@@ -152,10 +152,41 @@ class TransactionServiceImplTest {
                                 anyString(), eq("TRANSFER_CAPTURE"));
                 verify(accountServiceClient).applyBalanceOperation(eq("acc2"), anyString(), eq(BigDecimal.valueOf(100)),
                                 anyString(), eq("TRANSFER_CREDIT"), eq(true));
+                verify(accountServiceClient).createNotification(any(ResilientAccountServiceClient.NotificationRequest.class));
                 verify(transactionRepository, atLeast(2)).save(any(Transaction.class));
                 verify(auditService).logTransactionInitiated(anyString(), eq(TransactionType.TRANSFER),
                                 eq("acc1"), eq("acc2"), eq(BigDecimal.valueOf(100)), eq(userId));
                 verify(metricsService).recordTransactionInitiated(TransactionType.TRANSFER);
+        }
+
+        @Test
+        void processTransfer_NotificationFailureDoesNotFailCompletedTransfer() {
+                when(accountServiceClient.getAccount("acc1")).thenReturn(fromAccount);
+                when(accountServiceClient.getAccount("acc2")).thenReturn(toAccount);
+                when(transactionRepository.save(any(Transaction.class))).thenReturn(transaction);
+                when(accountServiceClient.placeDebitHold(eq("acc1"), anyString(), eq(BigDecimal.valueOf(100)),
+                                anyString(), eq("TRANSFER_HOLD")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-transfer",
+                                                1L, true, BigDecimal.valueOf(1000), BigDecimal.valueOf(900),
+                                                "PLACED", null));
+                when(accountServiceClient.captureDebitHold(eq("acc1"), anyString(), anyString(),
+                                eq("TRANSFER_CAPTURE")))
+                                .thenReturn(new ResilientAccountServiceClient.DebitHoldResponse("hold-transfer",
+                                                1L, true, BigDecimal.valueOf(900), BigDecimal.valueOf(900),
+                                                "CAPTURED", null));
+                when(accountServiceClient.applyBalanceOperation(eq("acc2"), anyString(), eq(BigDecimal.valueOf(100)),
+                                anyString(), eq("TRANSFER_CREDIT"), eq(true)))
+                                .thenReturn(new ResilientAccountServiceClient.BalanceOperationResponse(2L, "op-credit",
+                                                true,
+                                                BigDecimal.valueOf(600), 1L, "APPLIED"));
+                doThrow(new RuntimeException("account service down"))
+                                .when(accountServiceClient)
+                                .createNotification(any(ResilientAccountServiceClient.NotificationRequest.class));
+
+                TransactionResponse result = transactionService.processTransfer(transferRequest, userId, null);
+
+                assertNotNull(result);
+                assertEquals(TransactionStatus.COMPLETED, result.getStatus());
         }
 
         @Test


### PR DESCRIPTION
## Summary

Adds a customer notification center across the backend services and frontend console.

- adds account-service notification persistence, filtering, summary, read, and internal creation APIs
- emits notifications from account status changes, completed/failed transactions, and dispute lifecycle events
- adds the customer Notifications page with unread badge, filtering, mark-read, and mark-all-read actions
- covers notification APIs, transaction/dispute emission, and frontend behavior with tests

## Validation

- `mvn -q test`
- `npm.cmd test`
- `npm.cmd run build`
- `git diff --check`
- Live browser demo of the customer notification center and admin console smoke check